### PR TITLE
fix: improve date handling again

### DIFF
--- a/src/api/sheet_test_client.rs
+++ b/src/api/sheet_test_client.rs
@@ -448,27 +448,29 @@ fn load_csv(csv_data: &str) -> Res<SheetData> {
 }
 
 /// Seed transaction data.
+/// Date column uses Y4 format (MM/DD/YYYY with leading zeros).
+/// Month, Week, DateAdded, CategorizedDate use Y2 format (M/D/YY without leading zeros).
 const TRANSACTION_DATA: &str = r##",Date,Description,Category,Amount,Account,Account #,Institution,Month,Week,Transaction ID,Account ID,Check Number,Full Description,Date Added,Categorized Date,Custom Column
-,10/20/2025,Whole Foods Market,Groceries,-$87.43,Credit Card 1,xxxx1234,Bank A,10/1/25,10/19/25,tx001a2b3c4d5e6f7g8h9i01,acct001a2b3c4d5e6f7g,,WHOLE FOODS MARKET,10/21/25,10/21/2025 9:15:30 AM,87.43
-,10/19/2025,Starbucks #2847,Coffee Shops,-$6.75,Credit Card 1,xxxx1234,Bank A,10/1/25,10/19/25,tx001a2b3c4d5e6f7g8h9i02,acct001a2b3c4d5e6f7g,,STARBUCKS #2847,10/20/25,10/20/2025 8:45:12 AM,6.75
-,10/18/2025,Shell Gas Station,Gas & Fuel,-$52.30,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i03,acct001a2b3c4d5e6f7g,,SHELL GAS STATION,10/19/25,10/19/2025 7:22:45 AM,52.30
-,10/17/2025,Chipotle Mexican Grill,Restaurants,-$14.85,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i04,acct001a2b3c4d5e6f7g,,CHIPOTLE MEXICAN GRILL,10/18/25,10/18/2025 12:35:20 PM,14.85
-,10/16/2025,PG&E Electric,Utilities,-$142.67,Checking 1,xxxx5678,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i05,acct002a2b3c4d5e6f7g,,PG&E ELECTRIC,10/17/25,10/17/2025 6:00:00 AM,142.67
-,10/15/2025,Trader Joe's #429,Groceries,-$63.21,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i06,acct001a2b3c4d5e6f7g,,TRADER JOE'S #429,10/16/25,10/16/2025 4:18:33 PM,63.21
-,10/14/2025,Peet's Coffee & Tea,Coffee Shops,-$7.25,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i07,acct001a2b3c4d5e6f7g,,PEET'S COFFEE & TEA,10/15/25,10/15/2025 9:22:18 AM,7.25
-,10/13/2025,Chevron Gas,Gas & Fuel,-$48.90,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i08,acct001a2b3c4d5e6f7g,,CHEVRON GAS,10/14/25,10/14/2025 5:45:09 PM,48.90
-,10/12/2025,Panera Bread,Restaurants,-$12.40,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i09,acct001a2b3c4d5e6f7g,,PANERA BREAD,10/13/25,10/13/2025 1:10:25 PM,12.40
-,10/11/2025,Comcast Internet,Utilities,-$89.99,Checking 1,xxxx5678,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i10,acct002a2b3c4d5e6f7g,,COMCAST INTERNET,10/12/25,10/12/2025 6:30:00 AM,89.99
-,10/10/2025,Safeway #1534,Groceries,-$95.82,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i11,acct001a2b3c4d5e6f7g,,SAFEWAY #1534,10/11/25,10/11/2025 3:42:15 PM,95.82
-,10/9/2025,Blue Bottle Coffee,Coffee Shops,-$8.50,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i12,acct001a2b3c4d5e6f7g,,BLUE BOTTLE COFFEE,10/10/25,10/10/2025 10:05:44 AM,8.50
-,10/8/2025,76 Gas Station,Gas & Fuel,-$55.20,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i13,acct001a2b3c4d5e6f7g,,76 GAS STATION,10/9/25,10/9/2025 6:18:52 PM,55.20
-,10/7/2025,Olive Garden,Restaurants,-$42.30,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i14,acct001a2b3c4d5e6f7g,,OLIVE GARDEN,10/8/25,10/8/2025 7:25:33 PM,42.30
-,10/6/2025,AT&T Wireless,Utilities,-$75.00,Checking 1,xxxx5678,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i15,acct002a2b3c4d5e6f7g,,AT&T WIRELESS,10/7/25,10/7/2025 6:00:00 AM,75.00
-,10/5/2025,Costco Wholesale,Groceries,-$118.56,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i16,acct001a2b3c4d5e6f7g,,COSTCO WHOLESALE,10/6/25,10/6/2025 2:30:18 PM,118.56
-,10/4/2025,Starbucks #1923,Coffee Shops,-$5.95,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i17,acct001a2b3c4d5e6f7g,,STARBUCKS #1923,10/5/25,10/5/2025 8:12:05 AM,5.95
-,10/3/2025,Shell Station #4521,Gas & Fuel,-$61.45,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i18,acct001a2b3c4d5e6f7g,,SHELL STATION #4521,10/4/25,10/4/2025 4:55:22 PM,61.45
-,10/2/2025,In-N-Out Burger,Restaurants,-$9.75,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i19,acct001a2b3c4d5e6f7g,,IN-N-OUT BURGER,10/3/25,10/3/2025 6:40:11 PM,9.75
-,10/1/2025,City Water District,,-$45.88,Checking 1,xxxx5678,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i20,acct002a2b3c4d5e6f7g,,CITY WATER DISTRICT,10/2/25,10/2/2025 6:00:00 AM,45.88
+,10/20/2025,Whole Foods Market,Groceries,-$87.43,Credit Card 1,xxxx1234,Bank A,10/1/25,10/19/25,tx001a2b3c4d5e6f7g8h9i01,acct001a2b3c4d5e6f7g,,WHOLE FOODS MARKET,10/21/25,10/21/25 9:15:30 AM,87.43
+,10/19/2025,Starbucks #2847,Coffee Shops,-$6.75,Credit Card 1,xxxx1234,Bank A,10/1/25,10/19/25,tx001a2b3c4d5e6f7g8h9i02,acct001a2b3c4d5e6f7g,,STARBUCKS #2847,10/20/25,10/20/25 8:45:12 AM,6.75
+,10/18/2025,Shell Gas Station,Gas & Fuel,-$52.30,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i03,acct001a2b3c4d5e6f7g,,SHELL GAS STATION,10/19/25,10/19/25 7:22:45 AM,52.30
+,10/17/2025,Chipotle Mexican Grill,Restaurants,-$14.85,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i04,acct001a2b3c4d5e6f7g,,CHIPOTLE MEXICAN GRILL,10/18/25,10/18/25 12:35:20 PM,14.85
+,10/16/2025,PG&E Electric,Utilities,-$142.67,Checking 1,xxxx5678,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i05,acct002a2b3c4d5e6f7g,,PG&E ELECTRIC,10/17/25,10/17/25 6:00:00 AM,142.67
+,10/15/2025,Trader Joe's #429,Groceries,-$63.21,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i06,acct001a2b3c4d5e6f7g,,TRADER JOE'S #429,10/16/25,10/16/25 4:18:33 PM,63.21
+,10/14/2025,Peet's Coffee & Tea,Coffee Shops,-$7.25,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i07,acct001a2b3c4d5e6f7g,,PEET'S COFFEE & TEA,10/15/25,10/15/25 9:22:18 AM,7.25
+,10/13/2025,Chevron Gas,Gas & Fuel,-$48.90,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i08,acct001a2b3c4d5e6f7g,,CHEVRON GAS,10/14/25,10/14/25 5:45:09 PM,48.90
+,10/12/2025,Panera Bread,Restaurants,-$12.40,Credit Card 1,xxxx1234,Bank A,10/1/25,10/12/25,tx001a2b3c4d5e6f7g8h9i09,acct001a2b3c4d5e6f7g,,PANERA BREAD,10/13/25,10/13/25 1:10:25 PM,12.40
+,10/11/2025,Comcast Internet,Utilities,-$89.99,Checking 1,xxxx5678,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i10,acct002a2b3c4d5e6f7g,,COMCAST INTERNET,10/12/25,10/12/25 6:30:00 AM,89.99
+,10/10/2025,Safeway #1534,Groceries,-$95.82,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i11,acct001a2b3c4d5e6f7g,,SAFEWAY #1534,10/11/25,10/11/25 3:42:15 PM,95.82
+,10/09/2025,Blue Bottle Coffee,Coffee Shops,-$8.50,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i12,acct001a2b3c4d5e6f7g,,BLUE BOTTLE COFFEE,10/10/25,10/10/25 10:05:44 AM,8.50
+,10/08/2025,76 Gas Station,Gas & Fuel,-$55.20,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i13,acct001a2b3c4d5e6f7g,,76 GAS STATION,10/9/25,10/9/25 6:18:52 PM,55.20
+,10/07/2025,Olive Garden,Restaurants,-$42.30,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i14,acct001a2b3c4d5e6f7g,,OLIVE GARDEN,10/8/25,10/8/25 7:25:33 PM,42.30
+,10/06/2025,AT&T Wireless,Utilities,-$75.00,Checking 1,xxxx5678,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i15,acct002a2b3c4d5e6f7g,,AT&T WIRELESS,10/7/25,10/7/25 6:00:00 AM,75.00
+,10/05/2025,Costco Wholesale,Groceries,-$118.56,Credit Card 1,xxxx1234,Bank A,10/1/25,10/5/25,tx001a2b3c4d5e6f7g8h9i16,acct001a2b3c4d5e6f7g,,COSTCO WHOLESALE,10/6/25,10/6/25 2:30:18 PM,118.56
+,10/04/2025,Starbucks #1923,Coffee Shops,-$5.95,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i17,acct001a2b3c4d5e6f7g,,STARBUCKS #1923,10/5/25,10/5/25 8:12:05 AM,5.95
+,10/03/2025,Shell Station #4521,Gas & Fuel,-$61.45,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i18,acct001a2b3c4d5e6f7g,,SHELL STATION #4521,10/4/25,10/4/25 4:55:22 PM,61.45
+,10/02/2025,In-N-Out Burger,Restaurants,-$9.75,Credit Card 1,xxxx1234,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i19,acct001a2b3c4d5e6f7g,,IN-N-OUT BURGER,10/3/25,10/3/25 6:40:11 PM,9.75
+,10/01/2025,City Water District,,-$45.88,Checking 1,xxxx5678,Bank A,10/1/25,9/28/25,tx001a2b3c4d5e6f7g8h9i20,acct002a2b3c4d5e6f7g,,CITY WATER DISTRICT,10/2/25,10/2/25 6:00:00 AM,45.88
 "##;
 
 /// Seed category data.

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -645,6 +645,19 @@ mod tests {
             history
         );
 
+        // Verify dates are written in US format (M/D/YYYY), not ISO format
+        if let Some(SheetCall::WriteRanges { ranges }) = write_calls.first() {
+            // Find the Transactions sheet data
+            if let Some((_, rows)) = ranges.iter().find(|(r, _)| r.contains("Transactions")) {
+                // Row 0 is header, row 1 is first data row. Column 1 is "Date"
+                let date_value = &rows[1][1];
+                assert!(
+                    date_value.contains('/'),
+                    "Date should be in US format (M/D/YYYY), got: {date_value}"
+                );
+            }
+        }
+
         // Verify clear happens before write
         let clear_idx = history
             .iter()
@@ -729,5 +742,67 @@ mod tests {
             "Error should mention formulas and suggest --formulas preserve or ignore, got: {}",
             err_msg
         );
+    }
+
+    #[tokio::test]
+    async fn test_sync_roundtrip_preserves_data() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        // Run sync_down to populate the database (this also seeds the TestSheet)
+        sync_down(config.clone(), Mode::Testing).await.unwrap();
+
+        // Capture original sheet state after sync_down (seed data is now loaded)
+        let test_sheet = TestSheet::new(config.spreadsheet_id());
+        let original_state = test_sheet.get_state();
+
+        // Clear history and run sync_up
+        test_sheet.clear_history();
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        // Get the data that was written during sync_up
+        let history = test_sheet.call_history();
+        let write_call = history
+            .iter()
+            .find(|c| matches!(c, SheetCall::WriteRanges { .. }))
+            .expect("sync_up should write data");
+
+        if let SheetCall::WriteRanges { ranges } = write_call {
+            // Compare Transactions data
+            let (_, written_transactions) = ranges
+                .iter()
+                .find(|(r, _)| r.contains("Transactions"))
+                .expect("Should write Transactions");
+            let original_transactions = original_state
+                .data
+                .get("Transactions")
+                .expect("Original should have Transactions");
+
+            // Compare row by row (both should have same number of rows)
+            assert_eq!(
+                written_transactions.len(),
+                original_transactions.len(),
+                "Transaction row count should match"
+            );
+
+            // Compare each cell value
+            for (row_idx, (written_row, original_row)) in written_transactions
+                .iter()
+                .zip(original_transactions.iter())
+                .enumerate()
+            {
+                for (col_idx, (written_val, original_val)) in
+                    written_row.iter().zip(original_row.iter()).enumerate()
+                {
+                    assert_eq!(
+                        written_val, original_val,
+                        "Mismatch at row {row_idx}, col {col_idx}: \
+                         written '{written_val}' != original '{original_val}'"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/model/date.rs
+++ b/src/model/date.rs
@@ -4,18 +4,47 @@
 
 use crate::error::{ErrorType, IntoResult, Res};
 use crate::TillerError;
-use anyhow::{bail, ensure, Context};
-use chrono::{DateTime, FixedOffset, NaiveDateTime};
+use anyhow::bail;
+use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime};
 use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
+use sqlx::encode::IsNull;
+use sqlx::error::BoxDynError;
+use sqlx::sqlite::{SqliteArgumentValue, SqliteTypeInfo, SqliteValueRef};
+use sqlx::{Decode, Encode, Sqlite, Type};
 use std::borrow::Cow;
 use std::fmt::{Debug, Display, Formatter};
 use std::str::FromStr;
-use tracing::debug;
 
 /// A date value that serializes in YYYY-MM-DD format.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, sqlx::Type)]
-#[sqlx(transparent)]
-pub struct Date(String);
+#[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub enum Date {
+    Naive(NaiveDate),
+    NaiveTime(NaiveDateTime),
+    Timestamp(DateTime<FixedOffset>),
+}
+
+impl Type<Sqlite> for Date {
+    fn type_info() -> SqliteTypeInfo {
+        <String as Type<Sqlite>>::type_info()
+    }
+
+    fn compatible(ty: &SqliteTypeInfo) -> bool {
+        <String as Type<Sqlite>>::compatible(ty)
+    }
+}
+
+impl Encode<'_, Sqlite> for Date {
+    fn encode_by_ref(&self, buf: &mut Vec<SqliteArgumentValue<'_>>) -> Result<IsNull, BoxDynError> {
+        Encode::<Sqlite>::encode(self.to_string(), buf)
+    }
+}
+
+impl Decode<'_, Sqlite> for Date {
+    fn decode(value: SqliteValueRef<'_>) -> Result<Self, BoxDynError> {
+        let s = <String as Decode<Sqlite>>::decode(value)?;
+        Date::parse(&s).map_err(|e| e.into())
+    }
+}
 
 impl JsonSchema for Date {
     fn schema_name() -> Cow<'static, str> {
@@ -26,29 +55,68 @@ impl JsonSchema for Date {
         json_schema!({
             "type": "string",
             "format": "date",
-            "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
-            "description": "A date in YYYY-MM-DD format (e.g., 2025-01-23)"
+            "description": "A date in YYYY-MM-DD format (e.g., 2025-01-23), or ISO 8601 RFC 3339"
         })
     }
 }
 
 impl Default for Date {
     fn default() -> Self {
-        Date("1999-12-31".to_string())
+        Date::Naive(NaiveDate::from_ymd_opt(1999, 12, 31).unwrap_or_default())
     }
 }
 
 impl Date {
     pub fn parse(s: impl AsRef<str>) -> Res<Self> {
         let s = s.as_ref();
-        if s.contains(':') {
-            Self::parse_with_chrono(s)
-        } else if s.contains('/') {
-            Self::parse_m_d_yyyy(s)
-        } else if s.contains('-') {
-            Self::parse_yyyy_mm_dd(s)
-        } else {
-            bail!("Expected a date eith in the format 9/30/2025 or 2025-09-31, but received {s}")
+
+        if let Some(d) = NAIVE_DATE_FORMATS
+            .iter()
+            .find_map(|&fmt| NaiveDate::parse_from_str(s, fmt).ok())
+        {
+            return Ok(Date::Naive(d));
+        }
+
+        if let Some(d) = NAIVE_DATE_TIME_FORMATS
+            .iter()
+            .find_map(|&fmt| NaiveDateTime::parse_from_str(s, fmt).ok())
+        {
+            return Ok(Date::NaiveTime(d));
+        }
+
+        if let Some(d) = DATE_TIME_FORMATS
+            .iter()
+            .find_map(|&fmt| DateTime::parse_from_str(s, fmt).ok())
+        {
+            return Ok(Date::Timestamp(d));
+        }
+
+        // Try RFC 3339 (handles Z suffix and standard timezone offsets)
+        if let Ok(d) = DateTime::parse_from_rfc3339(s) {
+            return Ok(Date::Timestamp(d));
+        }
+
+        bail!("Unable to parse {s} as a date")
+    }
+
+    /// Print the date in the format that Tiller uses in the spreadsheet.
+    /// - `6/30/2025` (i.e. US Date)
+    /// - `01/21/2026 4:37:48 AM` (i.e. US Date plush AM/PM time without timezone)
+    ///
+    /// Note: we will lose time zone information in the Google sheet so please don't expect it or
+    /// use it for anything important!
+    pub(crate) fn to_sheet_string(&self, y: Y) -> String {
+        match y {
+            Y::Y2 => match self {
+                Date::Naive(d) => d.format("%-m/%-d/%y").to_string(),
+                Date::NaiveTime(d) => d.format("%-m/%-d/%y %-I:%M:%S %p").to_string(),
+                Date::Timestamp(d) => d.format("%-m/%-d/%y %-I:%M:%S %p").to_string(),
+            },
+            Y::Y4 => match self {
+                Date::Naive(d) => d.format("%m/%d/%Y").to_string(),
+                Date::NaiveTime(d) => d.format("%m/%d/%Y %I:%M:%S %p").to_string(),
+                Date::Timestamp(d) => d.format("%m/%d/%Y %I:%M:%S %p").to_string(),
+            },
         }
     }
 
@@ -69,81 +137,15 @@ impl Date {
             Ok(Some(Self::parse(s)?))
         }
     }
+}
 
-    fn parse_m_d_yyyy(s: &str) -> Res<Self> {
-        let mut parts = s.split('/');
-        let m = parts.next().context(format!("No month found for {s}"))?;
-        let d = parts.next().context(format!("No day found for {s}"))?;
-        let y = parts.next().context(format!("No year found for {s}"))?;
-        ensure!(parts.next().is_none(), "Too many parts found for {s}");
-        Self::from_y_m_d(y, m, d, s)
-    }
-
-    fn parse_yyyy_mm_dd(s: &str) -> Res<Self> {
-        let mut parts = s.split('-');
-        let y = parts.next().context(format!("No year found for {s}"))?;
-        let m = parts.next().context(format!("No month found for {s}"))?;
-        let d = parts.next().context(format!("No day found for {s}"))?;
-        ensure!(parts.next().is_none(), "Too many parts found for {s}");
-        Self::from_y_m_d(y, m, d, s)
-    }
-
-    /// This is the format that Tiller uses for categorized date.
-    /// Handles multiple formats:
-    /// - `M/D/YYYY H:MM:SS AM/PM` (US format) -> outputs without timezone
-    /// - `YYYY-MM-DDTHH:MM:SS` (ISO without timezone) -> outputs without timezone
-    /// - `YYYY-MM-DDTHH:MM:SS-08:00` (ISO with timezone offset) -> preserves timezone
-    /// - `YYYY-MM-DDTHH:MM:SS.ffffffZ` (ISO with fractional seconds and Z) -> preserves Z
-    fn parse_with_chrono(s: &str) -> Res<Self> {
-        if s.contains('/') {
-            // US format: M/D/YYYY H:MM:SS AM/PM -> no timezone
-            let d = NaiveDateTime::parse_from_str(s, "%m/%d/%Y %I:%M:%S %p")
-                .context(format!("Unable to parse {s} as a date"))?;
-            Ok(Self(d.format("%Y-%m-%dT%H:%M:%S").to_string()))
-        } else if s.ends_with('Z') || s.contains('+') || s.rfind('-').is_some_and(|i| i > 10) {
-            // ISO format with timezone: preserve the offset
-            // The rfind('-') > 10 check distinguishes timezone offset from date separator
-            let dt = DateTime::<FixedOffset>::parse_from_rfc3339(s)
-                .or_else(|_| DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%z"))
-                .or_else(|_| DateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f%z"))
-                .context(format!("Unable to parse {s} as a date with timezone"))?;
-            // Format with timezone offset preserved (RFC3339 style: -08:00)
-            Ok(Self(dt.format("%Y-%m-%dT%H:%M:%S%:z").to_string()))
-        } else {
-            // ISO format without timezone
-            let d = NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S")
-                .or_else(|_| NaiveDateTime::parse_from_str(s, "%Y-%m-%dT%H:%M:%S%.f"))
-                .context(format!("Unable to parse {s} as a date"))?;
-            Ok(Self(d.format("%Y-%m-%dT%H:%M:%S").to_string()))
-        }
-    }
-
-    fn from_y_m_d(y: &str, m: &str, d: &str, original: &str) -> Res<Self> {
-        let m = m
-            .parse::<i32>()
-            .context(format!("Month is a bad number for {original}, m={m}"))?;
-        let d = d
-            .parse::<i32>()
-            .context(format!("Day is a bad number for {original}, d={d}"))?;
-        let mut y = y
-            .parse::<i32>()
-            .context(format!("Year is a bad number for {original}, y={y}"))?;
-        // Yuck... but, ok, let's support two-digit dates
-        if y < 100 {
-            debug!("A two-digit year was interpreted to be in the 21st century: {original}");
-            y += 2000;
-        }
-        ensure!(
-            (1..=12).contains(&m),
-            "Bad month value of {m} in {original}"
-        );
-        ensure!((1..=31).contains(&d), "Bad day value of {d} in {original}");
-        ensure!(
-            (1000..=9999).contains(&y),
-            "Bad year value of {y} in {original}"
-        );
-        Ok(Self(format!("{y:04}-{m:02}-{d:02}")))
-    }
+/// Whether the date should be printed with a 2-digit or 4-digit year.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub(crate) enum Y {
+    /// Two digit year
+    Y2,
+    /// Four digit year
+    Y4,
 }
 
 impl TryFrom<String> for Date {
@@ -164,13 +166,12 @@ impl TryFrom<&str> for Date {
 
 impl Display for Date {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
-    }
-}
-
-impl Debug for Date {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&self.0, f)
+        let s = match self {
+            Date::Naive(d) => d.format("%Y-%m-%d").to_string(),
+            Date::NaiveTime(d) => d.format("%Y-%m-%dT%H:%M:%S").to_string(),
+            Date::Timestamp(d) => d.to_rfc3339(),
+        };
+        Display::fmt(&s, f)
     }
 }
 
@@ -182,6 +183,7 @@ impl FromStr for Date {
     }
 }
 
+/// This trait allows us to parse a date from an option conveniently.
 pub(crate) trait DateFromOpt: Sized {
     fn date_from_opt(self) -> Res<Option<Date>>;
 }
@@ -196,6 +198,8 @@ where
     }
 }
 
+/// This allows us to conveniently parse a Date from a string that might be empty, where we want to
+/// treat the empty string as `None`.
 pub(crate) trait DateFromOptStr: Sized {
     fn date_from_opt_s(self) -> Res<Option<Date>>;
 }
@@ -209,40 +213,123 @@ where
     }
 }
 
-pub(crate) trait DateCanBeEmptyStr {
-    fn date_to_s(&self) -> String;
+/// This is a convenient serialization function to print out the date for Google sheet upload where
+/// we want it in the US Date format (`5/30/2025`)) to match Tiller, and if the Option is `None`
+/// then we want an empty string.
+pub(crate) trait DateToSheetStr {
+    fn d_to_s(&self, y: Y) -> String;
 }
 
-impl DateCanBeEmptyStr for Option<Date> {
-    fn date_to_s(&self) -> String {
-        self.as_ref().map(|d| d.to_string()).unwrap_or_default()
+impl DateToSheetStr for Date {
+    fn d_to_s(&self, y: Y) -> String {
+        self.to_sheet_string(y)
     }
 }
 
-impl DateCanBeEmptyStr for Option<&Date> {
-    fn date_to_s(&self) -> String {
-        self.map(|d| d.to_string()).unwrap_or_default()
+impl DateToSheetStr for &Date {
+    fn d_to_s(&self, y: Y) -> String {
+        self.to_sheet_string(y)
     }
 }
 
-impl DateCanBeEmptyStr for &Option<Date> {
-    fn date_to_s(&self) -> String {
-        self.as_ref().map(|d| d.to_string()).unwrap_or_default()
+impl DateToSheetStr for Option<Date> {
+    fn d_to_s(&self, y: Y) -> String {
+        self.as_ref()
+            .map(|d| d.to_sheet_string(y))
+            .unwrap_or_default()
+    }
+}
+
+impl DateToSheetStr for Option<&Date> {
+    fn d_to_s(&self, y: Y) -> String {
+        self.map(|d| d.to_sheet_string(y)).unwrap_or_default()
+    }
+}
+
+impl DateToSheetStr for &Option<Date> {
+    fn d_to_s(&self, y: Y) -> String {
+        self.as_ref()
+            .map(|d| d.to_sheet_string(y))
+            .unwrap_or_default()
     }
 }
 
 serde_plain::derive_deserialize_from_fromstr!(Date, "Valid date in M/D/YYYY or YYYY-MM-DD");
 serde_plain::derive_serialize_from_display!(Date);
 
+const NAIVE_DATE_FORMATS: [&str; 23] = [
+    // ISO 8601 / RFC 3339 variants
+    "%Y-%m-%d", // 2025-01-24
+    "%Y%m%d",   // 20250124
+    // US formats
+    "%m/%d/%y", // 01/24/25
+    "%m-%d-%y", // 01-24-25
+    "%m/%d/%Y", // 01/24/2025
+    "%m-%d-%Y", // 01-24-2025
+    "%m.%d.%Y", // 01.24.2025
+    // European formats
+    "%d/%m/%y", // 24/01/25
+    "%d-%m-%y", // 24-01-25
+    "%d.%m.%y", // 24.01.25
+    "%d/%m/%Y", // 24/01/2025
+    "%d-%m-%Y", // 24-01-2025
+    "%d.%m.%Y", // 24.01.2025
+    // Written months (English)
+    "%d-%b-%y",  // 24-Jan-25
+    "%B %d, %Y", // January 24, 2025
+    "%b %d, %Y", // Jan 24, 2025
+    "%d %B %Y",  // 24 January 2025
+    "%d %b %Y",  // 24 Jan 2025
+    "%B %d %Y",  // January 24 2025
+    "%b %d %Y",  // Jan 24 2025
+    "%d-%b-%Y",  // 24-Jan-2025
+    // Misc
+    "%Y/%m/%d", // 2025/01/24
+    "%Y.%m.%d", // 2025.01.24
+];
+
+const NAIVE_DATE_TIME_FORMATS: [&str; 12] = [
+    // ISO 8601 / RFC 3339 variants
+    "%Y-%m-%dT%H:%M:%S",    // 2025-01-24T14:30:00
+    "%Y-%m-%dT%H:%M:%S%.f", // 2025-01-24T14:30:00.123456
+    "%Y%m%dT%H%M%S",        // 20250124T143000
+    // With time (common)
+    "%Y-%m-%d %H:%M:%S",    // 2025-01-24 14:30:00
+    "%Y-%m-%d %H:%M",       // 2025-01-24 14:30
+    "%m/%d/%y %H:%M:%S",    // 01/24/25 14:30:00
+    "%m/%d/%y %I:%M:%S %p", // 01/24/25 02:30:00 PM
+    "%d/%m/%y %H:%M:%S",    // 24/01/25 14:30:00
+    "%m/%d/%Y %H:%M:%S",    // 01/24/2025 14:30:00
+    "%m/%d/%Y %I:%M:%S %p", // 01/24/2025 02:30:00 PM
+    "%d/%m/%Y %H:%M:%S",    // 24/01/2025 14:30:00
+    // Unix/log style
+    "%b %d %H:%M:%S %Y", // Jan 24 14:30:00 2025
+];
+
+const DATE_TIME_FORMATS: [&str; 12] = [
+    // ISO 8601 / RFC 3339 variants
+    "%Y-%m-%dT%H:%M:%S%Z",    // 2025-01-24T14:30:00Z
+    "%Y-%m-%dT%H:%M:%S%z",    // 2025-01-24T14:30:00+0000
+    "%Y-%m-%dT%H:%M:%S%.f%Z", // 2025-01-24T14:30:00.123456Z
+    "%Y-%m-%dT%H:%M:%S%.f%z", // 2025-01-24T14:30:00.123456+0000
+    "%Y%m%dT%H%M%S%Z",        // 20250124T143000Z
+    "%Y%m%dT%H%M%S%z",        // 20250124T143000+0000
+    "%Y-%m-%d %H:%M:%S%Z",    // 2025-01-24 14:30:00Z
+    "%Y-%m-%d %H:%M:%S%z",    // 2025-01-24 14:30:00+0000
+    "%Y-%m-%d %H:%M:%S%.f%Z", // 2025-01-24 14:30:00.123456Z
+    "%Y-%m-%d %H:%M:%S%.f%z", // 2025-01-24 14:30:00.123456+0000
+    "%Y%m%d %H%M%S%Z",        // 20250124 143000Z
+    "%Y%m%d %H%M%S%z",        // 20250124 143000+0000
+];
+
 #[cfg(test)]
 mod test {
     use super::*;
 
-    fn success_case(input: &str, expected_s: &str) {
-        let text = format!("Test failure parsing {input} and expecting {expected_s}");
-        let expected = Date(String::from(expected_s.to_string()));
+    fn success_case(input: &str, expected: &str, sheet_y2: &str, sheet_y4: &str) {
+        let text = format!("Test failure parsing {input} and expecting {expected}");
         let actual = Date::parse(&input).expect(&text);
-        assert_eq!(expected, actual);
+        assert_eq!(expected, actual.to_string());
 
         let json_str = format!("[\"{input}\"]");
         let arr: Vec<Date> = serde_json::from_str(&json_str).expect(&format!(
@@ -250,11 +337,22 @@ mod test {
         ));
         let serialized =
             serde_json::to_string(&arr).expect(&format!("{text}, unable to serialize"));
-        let json_expected = format!("[\"{expected_s}\"]");
+        let json_expected = format!("[\"{expected}\"]");
         assert_eq!(
             json_expected, serialized,
             "{text}, did not get the expected serialization"
-        )
+        );
+
+        let actual_sheet_y2 = actual.d_to_s(Y::Y2);
+        assert_eq!(
+            sheet_y2, actual_sheet_y2,
+            "{text} Sheet Y2 formatting is incorrect"
+        );
+        let actual_sheet_y4 = actual.d_to_s(Y::Y4);
+        assert_eq!(
+            sheet_y4, actual_sheet_y4,
+            "{text} Sheet Y4 formatting is incorrect"
+        );
     }
 
     fn failure_case(input: &str) {
@@ -274,27 +372,34 @@ mod test {
 
     #[test]
     fn test_parse_good_1() {
-        success_case("9/30/2025", "2025-09-30");
+        success_case("9/30/2025", "2025-09-30", "9/30/25", "09/30/2025");
     }
 
     #[test]
     fn test_parse_good_2() {
-        success_case("2025-09-30", "2025-09-30");
+        success_case("2025-09-30", "2025-09-30", "9/30/25", "09/30/2025");
     }
 
     #[test]
     fn test_parse_good_3() {
-        success_case("1999-6-2", "1999-06-02");
+        success_case("1999-6-2", "1999-06-02", "6/2/99", "06/02/1999");
     }
 
     #[test]
-    fn test_parse_good_4() {
-        success_case("12/000001/1932", "1932-12-01");
+    fn test_parse_bad_leading_zeros() {
+        failure_case("12/000001/1932");
     }
 
     #[test]
     fn test_parse_good_5() {
-        success_case("10/31/5", "2005-10-31");
+        // 2-digit years are interpreted by chrono (5 -> 2005)
+        success_case("10/31/05", "2005-10-31", "10/31/05", "10/31/2005");
+    }
+
+    #[test]
+    fn test_parse_good_6() {
+        // 2-digit years are interpreted by chrono (5 -> 2005)
+        success_case("10/1/25", "2025-10-01", "10/1/25", "10/01/2025");
     }
 
     #[test]
@@ -316,37 +421,72 @@ mod test {
 
     #[test]
     fn test_parse_chrono_iso_format() {
-        success_case("2025-01-23T10:30:45", "2025-01-23T10:30:45");
+        success_case(
+            "2025-01-23T10:30:45",
+            "2025-01-23T10:30:45",
+            "1/23/25 10:30:45 AM",
+            "01/23/2025 10:30:45 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_iso_midnight() {
-        success_case("2025-12-31T00:00:00", "2025-12-31T00:00:00");
+        success_case(
+            "2025-12-31T00:00:00",
+            "2025-12-31T00:00:00",
+            "12/31/25 12:00:00 AM",
+            "12/31/2025 12:00:00 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_iso_end_of_day() {
-        success_case("2025-06-15T23:59:59", "2025-06-15T23:59:59");
+        success_case(
+            "2025-06-15T23:59:59",
+            "2025-06-15T23:59:59",
+            "6/15/25 11:59:59 PM",
+            "06/15/2025 11:59:59 PM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_us_format_am() {
-        success_case("01/23/2025 10:30:45 AM", "2025-01-23T10:30:45");
+        success_case(
+            "01/23/2025 10:30:45 AM",
+            "2025-01-23T10:30:45",
+            "1/23/25 10:30:45 AM",
+            "01/23/2025 10:30:45 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_us_format_pm() {
-        success_case("01/23/2025 02:30:45 PM", "2025-01-23T14:30:45");
+        success_case(
+            "01/23/2025 02:30:45 PM",
+            "2025-01-23T14:30:45",
+            "1/23/25 2:30:45 PM",
+            "01/23/2025 02:30:45 PM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_us_format_noon() {
-        success_case("07/04/2025 12:00:00 PM", "2025-07-04T12:00:00");
+        success_case(
+            "07/04/2025 12:00:00 PM",
+            "2025-07-04T12:00:00",
+            "7/4/25 12:00:00 PM",
+            "07/04/2025 12:00:00 PM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_us_format_midnight() {
-        success_case("12/25/2025 12:00:00 AM", "2025-12-25T00:00:00");
+        success_case(
+            "12/25/2025 12:00:00 AM",
+            "2025-12-25T00:00:00",
+            "12/25/25 12:00:00 AM",
+            "12/25/2025 12:00:00 AM",
+        );
     }
 
     #[test]
@@ -369,36 +509,64 @@ mod test {
     #[test]
     fn test_parse_chrono_with_negative_offset() {
         // Input has -0800 offset, output should have -08:00 (RFC3339 style)
-        success_case("2024-12-31T06:17:17-0800", "2024-12-31T06:17:17-08:00");
+        success_case(
+            "2024-12-31T06:17:17-0800",
+            "2024-12-31T06:17:17-08:00",
+            "12/31/24 6:17:17 AM",
+            "12/31/2024 06:17:17 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_with_positive_offset() {
-        success_case("2025-01-23T15:30:00+0530", "2025-01-23T15:30:00+05:30");
+        success_case(
+            "2025-01-23T15:30:00+0530",
+            "2025-01-23T15:30:00+05:30",
+            "1/23/25 3:30:00 PM",
+            "01/23/2025 03:30:00 PM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_with_rfc3339_offset() {
         // Already in RFC3339 format with colon
-        success_case("2025-01-23T10:00:00-05:00", "2025-01-23T10:00:00-05:00");
+        success_case(
+            "2025-01-23T10:00:00-05:00",
+            "2025-01-23T10:00:00-05:00",
+            "1/23/25 10:00:00 AM",
+            "01/23/2025 10:00:00 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_with_z_suffix() {
-        success_case("2025-01-23T10:00:00Z", "2025-01-23T10:00:00+00:00");
+        success_case(
+            "2025-01-23T10:00:00Z",
+            "2025-01-23T10:00:00+00:00",
+            "1/23/25 10:00:00 AM",
+            "01/23/2025 10:00:00 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_with_fractional_seconds_and_z() {
-        // Fractional seconds should be dropped, Z converted to +00:00
-        success_case("2025-01-23T10:00:00.123456Z", "2025-01-23T10:00:00+00:00");
+        // Fractional seconds are preserved in ISO, dropped in sheet format
+        success_case(
+            "2025-01-23T10:00:00.123456Z",
+            "2025-01-23T10:00:00.123456+00:00",
+            "1/23/25 10:00:00 AM",
+            "01/23/2025 10:00:00 AM",
+        );
     }
 
     #[test]
     fn test_parse_chrono_with_fractional_seconds_and_offset() {
+        // Fractional seconds are preserved in ISO, dropped in sheet format
         success_case(
             "2024-12-31T06:17:17.465339-08:00",
-            "2024-12-31T06:17:17-08:00",
+            "2024-12-31T06:17:17.465339-08:00",
+            "12/31/24 6:17:17 AM",
+            "12/31/2024 06:17:17 AM",
         );
     }
 }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -12,7 +12,7 @@ pub use amount::{Amount, AmountFormat};
 pub use auto_cat::{AutoCat, AutoCatUpdates, AutoCats};
 pub use category::{Categories, Category, CategoryUpdates};
 pub use date::Date;
-pub(crate) use date::{DateCanBeEmptyStr, DateFromOpt, DateFromOptStr};
+pub(crate) use date::{DateFromOpt, DateFromOptStr, DateToSheetStr};
 pub(crate) use items::Item;
 pub(crate) use mapping::Mapping;
 pub(crate) use row_col::RowCol;

--- a/src/model/transaction.rs
+++ b/src/model/transaction.rs
@@ -1,6 +1,7 @@
 use crate::error::Res;
+use crate::model::date::Y;
 use crate::model::items::{Item, Items};
-use crate::model::{Amount, Date, DateCanBeEmptyStr, DateFromOptStr};
+use crate::model::{Amount, Date, DateFromOptStr, DateToSheetStr};
 use crate::utils;
 use anyhow::bail;
 use clap::Parser;
@@ -152,24 +153,24 @@ impl Item for Transaction {
         match TransactionColumn::from_header(header) {
             Ok(col) => match col {
                 TransactionColumn::TransactionId => self.transaction_id.clone(),
-                TransactionColumn::Date => self.date.to_string(),
+                TransactionColumn::Date => self.date.d_to_s(Y::Y4),
                 TransactionColumn::Description => self.description.clone(),
                 TransactionColumn::Amount => self.amount.to_string(),
                 TransactionColumn::Account => self.account.clone(),
                 TransactionColumn::AccountNumber => self.account_number.clone(),
                 TransactionColumn::Institution => self.institution.clone(),
-                TransactionColumn::Month => self.month.date_to_s(),
-                TransactionColumn::Week => self.week.date_to_s(),
+                TransactionColumn::Month => self.month.d_to_s(Y::Y2),
+                TransactionColumn::Week => self.week.d_to_s(Y::Y2),
                 TransactionColumn::FullDescription => self.full_description.clone(),
                 TransactionColumn::AccountId => self.account_id.clone(),
                 TransactionColumn::CheckNumber => self.check_number.clone(),
-                TransactionColumn::DateAdded => self.date_added.date_to_s(),
+                TransactionColumn::DateAdded => self.date_added.d_to_s(Y::Y2),
                 TransactionColumn::MerchantName => self.merchant_name.clone(),
                 TransactionColumn::CategoryHint => self.category_hint.clone(),
                 TransactionColumn::Category => self.category.clone(),
                 TransactionColumn::Note => self.note.clone(),
                 TransactionColumn::Tags => self.tags.clone(),
-                TransactionColumn::CategorizedDate => self.categorized_date.date_to_s(),
+                TransactionColumn::CategorizedDate => self.categorized_date.d_to_s(Y::Y2),
                 TransactionColumn::Statement => self.statement.clone(),
                 TransactionColumn::Metadata => self.metadata.clone(),
                 TransactionColumn::NoName => self.no_name.clone(),


### PR DESCRIPTION
We do not want errors when parsing dates if we can avoid it, and we want to reasonably match the date format that Tiller is using when we do a sync up. This commit overhauls the Date type to attempt these goals. We are now fairly deep in the DateTime rabbit-hole.

Further fix for #28