### PR TITLE
refactor: stop gating MCP tools behind an initialization call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,16 @@ For dead code warnings during incremental development:
 The MCP server has two important documentation files in `src/mcp/docs/`:
 
 - **`INTRO.md`**: Brief description shown to the AI client upon MCP server initialization (via
-  `ServerInfo.instructions`). Keep this concise.
-- **`INSTRUCTIONS.md`**: In-depth usage guide that the agent must read before using tools. This is
-  returned by the `initialize_service` tool and contains detailed information about workflows,
-  parameters, and best practices.
+  `ServerInfo.instructions`). Keep this concise: every client pays for it in context on every
+  session, whether or not tiller is used.
+- **`INSTRUCTIONS.md`**: In-depth usage guide, returned by the optional `instructions` tool. It
+  contains detailed information about workflows, parameters, and best practices.
+
+Calling `instructions` is NOT a precondition for using the other tools. An earlier design gated
+every tool behind an `initialize_service` call; that was removed because forcing a help lookup
+before any real work is possible makes the server behave unlike every other MCP server. Do not
+reintroduce a gate. Anything an agent must know in order to use a tool safely belongs in that tool's
+own doc comment.
 
 ### Restrictive use of Pub
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- MCP tools no longer require an `initialize_service` call before they can be used. The tool is
+  replaced by an optional `instructions` tool that returns the same in-depth guide, and the
+  server's `ServerInfo.instructions` is now a concise orientation.
 - Update dependencies, including major-version upgrades of `rmcp` (0.12 to 3) and `sqlx` (0.8 to
   0.9)
+
+### Removed
+
+- The `initialize_service` MCP tool. Use `instructions` instead; it is no longer a precondition for
+  calling anything else.
 
 ## [v0.2.1] - 2025-01-25
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Once configured, Claude Code can use the following tools:
 - **insert_transaction** / **update_transactions** / **delete_transactions**: Manage transactions
 - **insert_category** / **update_categories** / **delete_categories**: Manage categories
 - **insert_autocat** / **update_autocats** / **delete_autocats**: Manage AutoCat rules
+- **instructions**: The in-depth usage guide, if the agent wants more than each tool's own
+  description
 
 ### Example Use Cases
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -726,6 +726,16 @@ MCP tools wrap CLI commands with equivalent parameters:
 - **sync_down**: Downloads data from Google Sheet to local SQLite. No parameters.
 - **sync_up**: Uploads data from local SQLite to Google Sheet. Parameters: `force` (bool),
   `formulas` (enum: unknown, preserve, ignore).
+- **instructions**: Returns the in-depth usage guide (`src/mcp/docs/INSTRUCTIONS.md`). No
+  parameters.
+
+Every tool is callable straight away. `instructions` is a convenience, not a precondition:
+each tool documents its own parameters and behavior in its description, and the concise
+orientation in `ServerInfo.instructions` covers the rest.
+
+**Historical note:** an earlier design gated every tool behind an `initialize_service` call, on the
+theory that agents treat `ServerInfo.instructions` as optional reading. Forcing a help lookup before
+any real work is possible makes the server behave unlike every other MCP server, and it was removed.
 
 ### Tool Responses
 

--- a/src/mcp/docs/INSTRUCTIONS.md
+++ b/src/mcp/docs/INSTRUCTIONS.md
@@ -4,6 +4,9 @@ This MCP server synchronizes financial data between a Tiller Google Sheet and a 
 database. The local database serves as a workspace for analysis and manipulation before syncing
 changes back to the sheet.
 
+Reading this is optional. Every tool documents its own parameters and behavior in its description;
+this guide covers the wider picture that spans several tools.
+
 ## Prerequisites
 
 The user must have already completed CLI setup before using these tools:

--- a/src/mcp/docs/INTRO.md
+++ b/src/mcp/docs/INTRO.md
@@ -1,11 +1,25 @@
-# MCP Service Description
+# Tiller Sync
 
-[Tiller](https://tiller.com/) is a third-party service that aggregates and categorizes financial
-transactions into a Google sheet.
+[Tiller](https://tiller.com/) aggregates and categorizes financial transactions into a Google Sheet.
+This server syncs that sheet with a local SQLite database, where the data can be queried and edited,
+and syncs changes back.
 
-This MCP server offers the user the ability to download these financial transactions into a local
-SQLite database for further analysis and manipulation. The local datastore may also be written back
-to the user's tiller Google sheet.
+Use it for anything about the user's spending, budget, transactions, categories, or AutoCat rules.
 
-You, the AI agent, **MUST** read the full instructions by calling __initialize_service__ before
-calling any other tools.
+## Tools
+
+- `sync_down` — download the sheet into the local database.
+- `sync_up` — upload the local database to the sheet.
+- `query` / `schema` — read-only SQL against the local database, and its structure.
+- `insert_*`, `update_*`, `delete_*` — edit transactions, categories, and AutoCat rules locally.
+- `instructions` — the in-depth guide, if you want more than each tool's own documentation.
+
+## What to know before you start
+
+- **Local edits are not automatically synced.** Nothing reaches the Google Sheet until `sync_up`.
+- **`sync_down` overwrites local changes.** Run it before *starting* a round of edits, not between
+  editing and `sync_up`. See `instructions` for how to check for remote changes without it.
+- **`force` and `formulas` on `sync_up` exist to prevent data loss.** Read `sync_up`'s own
+  documentation before setting either.
+- Setup (`tiller init` and `tiller auth`) happens on the command line, not through this server. If
+  the tools report an authentication error, ask the user to run `tiller auth` in a terminal.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3,28 +3,15 @@
 //! This module provides an MCP server that exposes tiller functionality as tools
 //! for AI agent integration. The server communicates via JSON-RPC over stdio.
 
-/// Checks if the server has been initialized and returns an error if not.
-macro_rules! require_init {
-    ($self:expr) => {
-        if !$self.check_initialized().await {
-            return Self::uninitialized();
-        }
-    };
-}
-
 mod mcp_utils;
 mod tools;
 
 use crate::{Config, Mode};
 use rmcp::handler::server::tool::ToolRouter;
-use rmcp::model::{
-    CallToolResult, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
-};
+use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::transport::stdio;
-use rmcp::ErrorData as McpError;
 use rmcp::{tool_handler, ServerHandler, ServiceExt};
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tracing::info;
 
 /// The tiller MCP server.
@@ -32,7 +19,6 @@ use tracing::info;
 /// This server exposes tiller sync functionality as MCP tools.
 #[derive(Debug, Clone)]
 pub struct TillerServer {
-    initialized: Arc<Mutex<bool>>,
     mode: Mode,
     config: Arc<Config>,
     tool_router: ToolRouter<TillerServer>,
@@ -42,21 +28,10 @@ impl TillerServer {
     /// Creates a new TillerServer with the given configuration.
     pub fn new(config: Config, mode: Mode) -> Self {
         Self {
-            initialized: Arc::new(Mutex::new(false)),
             mode,
             config: Arc::new(config),
             tool_router: Self::tool_router(),
         }
-    }
-
-    async fn check_initialized(&self) -> bool {
-        *self.initialized.lock().await
-    }
-
-    fn uninitialized() -> Result<CallToolResult, McpError> {
-        Ok(CallToolResult::error(vec![rmcp::model::ContentBlock::text(
-            "You have not yet initialized the service. Please call __initialize_service__ first.",
-        )]))
     }
 }
 
@@ -64,11 +39,10 @@ impl TillerServer {
 impl ServerHandler for TillerServer {
     /// Returns server information sent to the MCP client during initialization.
     ///
-    /// The `instructions` field is intended by the specification to be the primary way to
-    /// communicate the server's purpose and usage to AI agents like Claude Code. This text is shown
-    /// to the AI to help it understand when and how to use this server's tools. However, it has
-    /// been noted that agents tend to consider this reading as optional. We have solved this
-    /// problem by requiring agents to call an `__initialize_service__` tool before anything else.
+    /// The `instructions` field is the specification's way of telling an AI client what this
+    /// server is for. It is deliberately short: the client pays for it in context on every session,
+    /// whether or not tiller ends up being used. The in-depth guide lives behind the `instructions`
+    /// tool, which the agent can call when it wants the detail.
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(include_str!("docs/INTRO.md"));
@@ -137,7 +111,7 @@ mod tests {
     use tokio::io::duplex;
 
     /// Integration test for the MCP server using an in-memory transport.
-    /// Tests initialize_service, sync_down, and sync_up tools.
+    /// Tests the sync_down, sync_up and update_transactions tools.
     #[tokio::test]
     async fn test_mcp_server_integration() {
         // Create duplex channel - one end for server, one for client
@@ -156,21 +130,8 @@ mod tests {
         // Create MCP client connected to the other end
         let client = ().serve(client_io).await.expect("Failed to create client");
 
-        // Test 1: Call initialize_service tool
-        let init_result = client
-            .call_tool(rmcp::model::CallToolRequestParams::new(
-                "initialize_service",
-            ))
-            .await
-            .expect("initialize_service call failed");
-
-        assert!(
-            !init_result.is_error.unwrap_or(false),
-            "initialize_service returned error: {:?}",
-            init_result.content
-        );
-
-        // Test 2: Call sync_down tool
+        // Test 1: sync_down works without any prior "initialization" call. The server used to
+        // reject every tool until `initialize_service` had been called at least once.
         let sync_down_result = client
             .call_tool(rmcp::model::CallToolRequestParams::new("sync_down"))
             .await
@@ -182,7 +143,7 @@ mod tests {
             sync_down_result.content
         );
 
-        // Test 3: Call sync_up tool with force and formulas params
+        // Test 2: Call sync_up tool with force and formulas params
         let mut args = serde_json::Map::new();
         args.insert("force".into(), serde_json::Value::Bool(true));
         args.insert(
@@ -201,7 +162,7 @@ mod tests {
             sync_up_result.content
         );
 
-        // Test 4: Call update_transaction tool
+        // Test 3: Call update_transaction tool
         // After sync_down, we have transactions in the database. Get one to update.
         let tiller_data = env.config().db().get_tiller_data().await.unwrap();
         let first_txn = &tiller_data.transactions.data()[0];
@@ -244,6 +205,50 @@ mod tests {
             server_result.is_ok(),
             "Server returned error: {:?}",
             server_result
+        );
+    }
+
+    /// The server used to reject every tool call until `initialize_service` had been called,
+    /// which forced a help lookup before any real work could start. Tools are now callable
+    /// straight away, like any other MCP server.
+    #[tokio::test]
+    async fn test_tools_need_no_initialization_call() {
+        let (client_io, server_io) = duplex(4096);
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        let _server_handle =
+            tokio::spawn(
+                async move { run_server(config, Mode::Testing, Io::Mock(server_io)).await },
+            );
+        let client = ().serve(client_io).await.expect("Failed to create client");
+
+        let tools = client
+            .list_tools(Default::default())
+            .await
+            .expect("Failed to list tools");
+        let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+
+        assert!(
+            !names.contains(&"initialize_service"),
+            "the initialization tool should be gone, found: {names:?}"
+        );
+        assert!(
+            names.contains(&"instructions"),
+            "the in-depth guide should still be reachable, found: {names:?}"
+        );
+
+        // Every tool must work as the very first call of the session. `schema` is the cheapest one
+        // that touches real state.
+        let result = client
+            .call_tool(rmcp::model::CallToolRequestParams::new("schema"))
+            .await
+            .expect("schema call failed");
+
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "a tool called before anything else should succeed, got: {:?}",
+            result.content
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -33,14 +33,14 @@ pub struct SyncUpParams {
 
 #[tool_router(vis = "pub(super)")]
 impl TillerServer {
+    /// Return the in-depth usage guide for this server.
+    ///
+    /// Optional. Every tool here documents its own parameters and behavior, so this is only worth
+    /// calling when you want the wider picture: the sync workflow, what each backup file is for,
+    /// how conflict detection and formula handling interact, the database schema, and example
+    /// queries.
     #[tool]
-    /// Initialize the tiller MCP service for this session and return usage instructions. You
-    /// **MUST** call this **ONCE** before using other tools so that you have the full usage
-    /// instructions. You **MAY** call it more than once if you have forgotten the usage
-    /// instructions.
-    async fn initialize_service(&self) -> Result<CallToolResult, McpError> {
-        let mut initialized = self.initialized.lock().await;
-        *initialized = true;
+    async fn instructions(&self) -> Result<CallToolResult, McpError> {
         Ok(CallToolResult::success(vec![
             rmcp::model::ContentBlock::text(include_str!("docs/INSTRUCTIONS.md")),
         ]))
@@ -75,7 +75,6 @@ impl TillerServer {
     /// if needed.
     #[tool]
     async fn sync_down(&self) -> Result<CallToolResult, McpError> {
-        require_init!(self);
         info!("MCP: sync_down called");
         let config = (*self.config).clone();
         let out = commands::sync_down(config, self.mode).await;
@@ -150,8 +149,6 @@ impl TillerServer {
         &self,
         Parameters(params): Parameters<SyncUpParams>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         info!(
             "MCP: sync_up called with force={}, formulas={}",
             params.force, params.formulas
@@ -205,8 +202,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateTransactionsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_transactions(config, args).await;
         tool_result(out)
@@ -265,8 +260,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateCategoriesArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_categories(config, args).await;
         tool_result(out)
@@ -327,8 +320,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateAutoCatsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_autocats(config, args).await;
         tool_result(out)
@@ -381,8 +372,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteTransactionsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_transactions(config, args).await;
         tool_result(out)
@@ -442,8 +431,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteCategoriesArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_categories(config, args).await;
         tool_result(out)
@@ -499,8 +486,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteAutoCatsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_autocats(config, args).await;
         tool_result(out)
@@ -559,8 +544,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertTransactionArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_transaction(config, args).await;
         tool_result(out)
@@ -612,8 +595,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertCategoryArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_category(config, args).await;
         tool_result(out)
@@ -692,8 +673,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertAutoCatArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_autocat(config, args).await;
         tool_result(out)
@@ -750,8 +729,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<QueryArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::query(config, args).await;
         tool_result(out)
@@ -820,8 +797,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<SchemaArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::schema(config, args).await;
         tool_result(out)


### PR DESCRIPTION
Not from an issue — this is the "forcing a help tool call before anything else is possible was a bad idea" change.

### What was there

Every tool body started with `require_init!(self)`, which returned *"You have not yet initialized the service. Please call `__initialize_service__` first."* unless that tool had been called at least once in the session. `INTRO.md` reinforced it: *"You, the AI agent, **MUST** read the full instructions by calling `__initialize_service__` before calling any other tools."*

### What's there now

The gate is gone — the `initialized` flag, the `require_init!` macro, and the rejection response. Tools are callable straight away, like any other MCP server.

`initialize_service` is replaced by `instructions`, returning the same guide as an ordinary optional tool. The rename is the point: the old name asserted that initialization was a thing an agent had to do, and an agent reading the tool list would reasonably infer it still had to call it first.

The guide isn't discarded, it just stops being mandatory:

- **Each tool's own description** already carries its parameters, behavior, backups, and failure modes. That is where an agent actually looks, and it's the right place for anything needed to use a tool safely.
- **`ServerInfo.instructions`** (`INTRO.md`) is rewritten as a real orientation — what the server is for, what the tools are, and the handful of things worth knowing before touching anything (local edits aren't synced until `sync_up`; `sync_down` overwrites; `force`/`formulas` exist to prevent data loss; setup happens on the CLI). It stays short on purpose: a client pays for it in context on every session, whether or not tiller gets used.
- **`INSTRUCTIONS.md`** stays as the wider picture behind the `instructions` tool, and now says up front that reading it is optional.

### Tests

`test_tools_need_no_initialization_call` lists the tools, asserts `initialize_service` is gone and `instructions` is present, and calls `schema` as the very first request of the session — which the old server would have rejected. The existing integration test now calls `sync_down` first, with no initialization step.

Tool count is 14 (was 14 — one removed, one added).

### Docs

`AGENTS.md` and `docs/DESIGN.md` both record why the gate existed and why it shouldn't come back, so a future agent working in this repo doesn't helpfully reinvent it.

`cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (216 tests) all pass.
