### PR TITLE
feat: stop sync down from silently discarding local edits (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `tiller status` (MCP: `sync_status`) reports what has changed locally and in the sheet since the
+  last sync, without modifying either. This makes it possible to check for remote changes without
+  running `sync down`. [#38]
+- `sync down` now refuses to run when the local datastore has changes that have not been uploaded,
+  naming what would be lost. `--force` discards them deliberately. [#38]
 - `sync up` reports how many formulas were written and reads the sheet back to check that they
   landed, warning if the counts disagree. [#35]
 
 ### Changed
 
+- Documentation no longer says to "always sync down first". Taken at face value after making local
+  edits, that advice reverts every local change. It is now scoped to the start of a round of edits.
+  [#38]
+- `sync up`'s conflict message names how many rows were added, modified, and deleted in the sheet
+  since the last download, instead of only saying that it changed.
 - MCP tools no longer require an `initialize_service` call before they can be used. The tool is
   replaced by an optional `instructions` tool that returns the same in-depth guide, and the
   server's `ServerInfo.instructions` is now a concise orientation.
@@ -119,5 +129,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [#35]: https://github.com/webern/tiller-sync/issues/35
 [#36]: https://github.com/webern/tiller-sync/issues/36
 [#37]: https://github.com/webern/tiller-sync/issues/37
+[#38]: https://github.com/webern/tiller-sync/issues/38
 [#40]: https://github.com/webern/tiller-sync/issues/40
 [#41]: https://github.com/webern/tiller-sync/issues/41

--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ This will:
 - Download Transactions, Categories, and AutoCat data from your Tiller sheet
 - Create a backup of the previous database state
 
+Run this at the **start** of a round of edits, never between editing and `tiller sync up`. It is not
+a refresh: transactions are overwritten from the sheet, and Categories and AutoCat are replaced
+outright, so any local change you have not uploaded is lost. It refuses to run when the local
+database has unsynced changes, and names what would be lost; `--force` discards them deliberately.
+
+To check whether the sheet has changed without downloading it, use `tiller status`.
+
 ### Sync Local Changes to Google Sheets
 
 Upload local changes back to your Tiller sheet:
@@ -173,6 +180,19 @@ This will:
 
 - Update your Google Sheets with any changes made to the local database
 - Create a backup before syncing
+
+### See What Has Changed
+
+```bash
+# What has changed locally, and what has changed in the sheet, since the last sync
+tiller status
+
+# Local changes only; does not read the sheet
+tiller status --local-only
+```
+
+Neither side is modified. Use this to check whether your local edits still need uploading, or
+whether the sheet has moved on, without running a sync in either direction.
 
 ### Query Data
 
@@ -261,6 +281,7 @@ claude mcp add tiller -- tiller --tiller-home /path/to/your/tiller mcp
 Once configured, Claude Code can use the following tools:
 
 - **sync_down** / **sync_up**: Sync data between your Google Sheet and local database
+- **sync_status**: See what has changed on each side since the last sync, without modifying either
 - **query**: Execute SQL queries against your local database
 - **schema**: View database structure and column descriptions
 - **insert_transaction** / **update_transactions** / **delete_transactions**: Manage transactions

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -101,6 +101,12 @@ Downloading changes from the Tiller Google Sheet:
 tiller sync down
 ```
 
+Seeing where the two sides stand, without modifying either:
+
+```bash
+tiller status
+```
+
 ### MCP
 
 The `tiller mcp` command launches an MCP server. See the dedicated MCP section later in this
@@ -264,6 +270,9 @@ Generated after successful OAuth consent flow. The file contains:
 
 During the `tiller sync down` call, the following happens.
 
+- The local datastore is compared against the last state both sides agreed on. If it has changes
+  that are not in the sheet, the command errors out and names what would be lost, since downloading
+  would discard them. `--force` proceeds anyway.
 - If the datastore does not exist, it is created.
 - A backup of the SQLite database is created.
 - If more than `backup_copies` of the SQLite database exist, the extras are deleted.
@@ -451,16 +460,64 @@ tiller sync down
 
 # 2. Make local edits in SQLite
 
-# 3. Upload local changes back to sheet
+# 3. See where things stand before syncing
+tiller status
+
+# 4. Upload local changes back to sheet
 tiller sync up
 ```
 
-**Forcing overwrites** (when local is authoritative):
+`sync down` belongs at the *start* of a round of edits, never between editing and `sync up`. It is
+not a refresh: transactions are upserted from the sheet, overwriting local field values, and
+Categories and AutoCat are deleted outright and replaced. `tiller status` is the way to check
+whether the sheet has moved on without downloading it.
+
+**Forcing overwrites** (when one side is authoritative):
 
 ```bash
-# Force upload despite remote changes
+# Discard local edits and take the sheet's contents
+tiller sync down --force
+
+# Overwrite sheet changes made since the last download
 tiller sync up --force
 ```
+
+### Change Detection
+
+Both sync directions and `tiller status` compare against the most recent `sync-down.*.json`
+snapshot, which records the last state both sides agreed on. `sync up` writes a fresh snapshot after
+a successful upload, from the sheet as re-read during verification; without that, every command
+after an upload would keep reporting the edits just uploaded as unsynced.
+
+Rows are compared by their **sheet representation** - the same strings a `sync up` would write.
+Comparing typed fields instead would report differences for values that round-trip through the
+database with a different but equivalent representation, and a check that cries wolf gets ignored.
+Two consequences follow:
+
+- A field with no column in the sheet is not compared. It cannot be uploaded, so a difference in it
+  could never be cleared by a `sync up` and would block `sync down` forever.
+- The unnamed column A that some sheets carry is not compared. It has no database column, so it
+  reads back empty and would make every row look modified.
+
+Transactions and categories are keyed by their primary key. AutoCat rules have no stable identity -
+their synthetic key is reassigned on every `sync down`, since the whole tab is replaced - so they are
+compared as a multiset of rows. Reordering the AutoCat tab is therefore not reported as a change.
+
+### `tiller status`
+
+Reports what has changed on each side since the last sync, modifying neither.
+
+```bash
+# Local and remote changes
+tiller status
+
+# Local changes only; does not read the sheet, so it needs no network or authentication
+tiller status --local-only
+```
+
+Its purpose is to make the two questions answerable separately: "have my local edits been
+uploaded?" and "has the sheet changed since I last downloaded?". The second used to require a
+`sync down`, which is exactly the operation that discards unsynced local edits.
 
 ### Row IDs
 
@@ -815,6 +872,8 @@ tiller schema --include-metadata
 
 Two new MCP tools wrap the CLI commands:
 
+- **sync_status**: Reports local and remote changes since the last sync. Parameters: `local_only`
+  (optional, defaults to false).
 - **query**: Executes arbitrary read-only SQL. Parameters: `sql` (required), `format` (required).
 - **schema**: Returns database schema information. Parameters: `include_metadata` (optional,
   defaults to false).

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -146,8 +146,10 @@ pub trait Tiller {
     ) -> Res<usize>;
 
     /// Verify that the write was successful by re-fetching the sheet.
-    /// Returns the observed counts if verification passes.
-    async fn verify_write(&mut self, expected: &TillerData) -> Res<WriteCounts>;
+    ///
+    /// Returns the observed counts and the sheet's contents. The contents are the new baseline for
+    /// conflict detection: once a `sync up` succeeds, this is what both sides agree on.
+    async fn verify_write(&mut self, expected: &TillerData) -> Res<(WriteCounts, TillerData)>;
 }
 
 /// What a `sync up` actually left behind in the Google sheet, read back after writing.

--- a/src/api/tiller.rs
+++ b/src/api/tiller.rs
@@ -91,7 +91,7 @@ impl Tiller for TillerImpl {
         Ok(formulas_written)
     }
 
-    async fn verify_write(&mut self, expected: &TillerData) -> Res<WriteCounts> {
+    async fn verify_write(&mut self, expected: &TillerData) -> Res<(WriteCounts, TillerData)> {
         use anyhow::bail;
 
         // Re-fetch data from sheets to verify row counts
@@ -134,7 +134,7 @@ impl Tiller for TillerImpl {
             );
         }
 
-        Ok(counts)
+        Ok((counts, actual))
     }
 }
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -95,6 +95,27 @@ pub enum Command {
     ///
     /// Returns tables, columns, types, indexes, foreign keys, column descriptions, and row counts.
     Schema(SchemaArgs),
+    /// Show what has changed locally and in the Google Sheet since the last sync.
+    ///
+    /// Neither side is modified. Use this to see whether local edits still need uploading, or
+    /// whether the sheet has moved on, without running a sync in either direction.
+    Status(StatusArgs),
+}
+
+/// Args for the `tiller status` command.
+///
+/// Reports edits made to the local datastore since the last sync (which `sync down` would discard)
+/// and edits made to the Google Sheet since the last sync (which `sync up` would overwrite).
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, JsonSchema, Default)]
+#[schemars(title = "StatusArgs")]
+pub struct StatusArgs {
+    /// Skip reading the Google Sheet and report local changes only.
+    ///
+    /// Reading the sheet needs network access and valid authentication. Use this when you only
+    /// want to know whether your local edits have been uploaded.
+    #[arg(long, default_value = "false")]
+    #[serde(default)]
+    pub local_only: bool,
 }
 
 /// Arguments common to all subcommands.
@@ -201,7 +222,11 @@ pub struct SyncArgs {
     /// The path to the Google OAuth token file, defaults to $TILLER_HOME/.secrets/token.json
     oauth_token: Option<PathBuf>,
 
-    /// Force sync up even if conflicts are detected or sync-down backup is missing
+    /// Proceed even when the sync would discard changes.
+    ///
+    /// For `sync down`, this discards local edits that have not been uploaded. For `sync up`, this
+    /// overwrites sheet changes made since the last download, and allows a sync up when no
+    /// sync-down backup exists.
     #[arg(long)]
     force: bool,
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod init;
 mod insert;
 mod mcp;
 pub mod query;
+mod status;
 mod sync;
 mod update;
 
@@ -25,6 +26,7 @@ pub use init::init;
 pub use insert::{insert_autocat, insert_category, insert_transaction};
 pub use mcp::mcp;
 pub use query::{query, schema, ColumnInfo, ForeignKeyInfo, IndexInfo, Rows, Schema, TableInfo};
+pub use status::{status, SyncStatus};
 pub use sync::{sync_down, sync_up};
 pub use update::{update_autocats, update_categories, update_transactions};
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,246 @@
+//! The `status` command: what has changed locally, and what has changed in the sheet.
+//!
+//! This exists so that "have my local edits been uploaded?" and "has the sheet changed since I last
+//! downloaded?" can be answered without running a sync. Answering the second question used to
+//! require a `sync down`, which is exactly the operation that discards unsynced local edits.
+//!
+//! See <https://github.com/webern/tiller-sync/issues/38>.
+
+use crate::api::{sheet, tiller, Mode, Tiller};
+use crate::backup::SYNC_DOWN;
+use crate::commands::sync::local_changes;
+use crate::commands::Out;
+use crate::error::{ErrorType, IntoResult};
+use crate::model::Changes;
+use crate::{Config, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+/// Where the local datastore and the Google Sheet stand relative to the last sync.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SyncStatus {
+    /// Whether a sync has ever run. Everything below is meaningless when this is false.
+    pub synced_before: bool,
+    /// Edits made to the local datastore since the last sync. `sync down` would discard these.
+    pub local: Changes,
+    /// Edits made to the Google Sheet since the last sync. `sync up` would overwrite these.
+    ///
+    /// Absent when the sheet was not read, which happens when `check_remote` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote: Option<Changes>,
+}
+
+impl Display for SyncStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string_pretty(self) {
+            Ok(s) => write!(f, "{s}"),
+            Err(_) => write!(f, "{self:?}"),
+        }
+    }
+}
+
+/// Reports what has changed locally and, optionally, in the Google Sheet.
+///
+/// Reading the sheet costs an API call and requires valid authentication, so `check_remote` makes
+/// it opt-out: the local half of the answer is always available offline.
+pub async fn status(config: Config, mode: Mode, check_remote: bool) -> Result<Out<SyncStatus>> {
+    let Some(local) = local_changes(&config).await? else {
+        return Ok(Out::new(
+            "No sync has run yet, so there is nothing to compare against. Run 'tiller sync down' \
+             to download the sheet.",
+            SyncStatus {
+                synced_before: false,
+                local: Changes::default(),
+                remote: None,
+            },
+        ));
+    };
+
+    let remote = if check_remote {
+        Some(remote_changes(&config, mode).await?)
+    } else {
+        None
+    };
+
+    let message = describe(&local, remote.as_ref());
+    Ok(Out::new(
+        message,
+        SyncStatus {
+            synced_before: true,
+            local,
+            remote,
+        },
+    ))
+}
+
+/// Compares the Google Sheet against the last known state of it.
+async fn remote_changes(config: &Config, mode: Mode) -> Result<Changes> {
+    let last_synced = config
+        .backup()
+        .load_latest_json(SYNC_DOWN)
+        .await
+        .pub_result(ErrorType::Internal)?
+        .ok_or_else(|| anyhow::anyhow!("No sync-down backup found"))
+        .pub_result(ErrorType::Internal)?;
+
+    let sheet_client = sheet(config.clone(), mode).await?;
+    let mut tiller_client = tiller(sheet_client).await.pub_result(ErrorType::Internal)?;
+    let current = tiller_client.get_data().await.pub_result(ErrorType::Sync)?;
+
+    Ok(Changes::between(&last_synced, &current))
+}
+
+/// Turns the comparison into a sentence that says what to do next.
+fn describe(local: &Changes, remote: Option<&Changes>) -> String {
+    let local_dirty = !local.is_empty();
+    let remote_dirty = remote.is_some_and(|r| !r.is_empty());
+
+    match (local_dirty, remote_dirty) {
+        (false, false) if remote.is_some() => {
+            "Local datastore and sheet are both in step with the last sync.".to_string()
+        }
+        (false, false) => "No local changes since the last sync.".to_string(),
+        (true, false) => format!(
+            "Local changes not yet in the sheet: {local}. Run 'tiller sync up' to upload them."
+        ),
+        (false, true) => format!(
+            "The sheet has changed since the last sync: {}. Run 'tiller sync down' to pull them in.",
+            remote.unwrap_or(&Changes::default())
+        ),
+        (true, true) => format!(
+            "Both sides have changed. Local: {local}. Sheet: {}. Neither sync direction can \
+             preserve both, so reconcile them before syncing, or choose a side with --force.",
+            remote.unwrap_or(&Changes::default())
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::DeleteTransactionsArgs;
+    use crate::commands::{sync_down, sync_up, FormulasMode};
+    use crate::model::TransactionUpdates;
+    use crate::test::TestEnv;
+
+    #[tokio::test]
+    async fn test_status_before_any_sync() {
+        let env = TestEnv::new().await;
+        let out = status(env.config(), Mode::Testing, false).await.unwrap();
+
+        assert!(!out.structure().unwrap().synced_before);
+        assert!(out.message().contains("No sync has run yet"));
+    }
+
+    #[tokio::test]
+    async fn test_status_is_clean_right_after_sync_down() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert!(structure.local.is_empty(), "local: {}", structure.local);
+        assert!(
+            structure.remote.unwrap().is_empty(),
+            "the sheet has not been touched"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_status_reports_local_edits() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, false).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert_eq!(structure.local.transactions.modified, 1);
+        assert!(
+            out.message().contains("sync up"),
+            "the message should say what to do, got: {}",
+            out.message()
+        );
+    }
+
+    /// The remote half is the point of the command: checking for sheet changes used to require a
+    /// `sync down`, which is the operation that discards local edits.
+    #[tokio::test]
+    async fn test_status_reports_remote_edits_without_downloading() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        // Edit the sheet behind the tool's back.
+        let mut state = env.get_state();
+        state.data.get_mut("Transactions").unwrap()[1][2].push_str(" (edited)");
+        env.set_state(state);
+
+        let out = status(config.clone(), Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert_eq!(structure.remote.unwrap().transactions.modified, 1);
+        assert!(structure.local.is_empty(), "the datastore was not touched");
+
+        // And the datastore was genuinely left alone.
+        let after = config.db().get_tiller_data().await.unwrap();
+        assert!(!after.transactions.data()[0]
+            .description
+            .contains("(edited)"));
+    }
+
+    /// After uploading, both sides agree again. Without a refreshed baseline, `status` and
+    /// `sync down` would keep reporting the just-uploaded edits as unsynced forever.
+    #[tokio::test]
+    async fn test_status_is_clean_after_sync_up() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let args = DeleteTransactionsArgs::new(vec![id]).unwrap();
+        crate::commands::delete_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert!(
+            structure.local.is_empty(),
+            "after uploading, the local datastore is in step: {}",
+            structure.local
+        );
+        assert!(
+            structure.remote.unwrap().is_empty(),
+            "after uploading, the sheet is in step"
+        );
+    }
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -2,13 +2,37 @@ use super::{FormulasMode, Out};
 use crate::api::{sheet, tiller, Mode, Tiller};
 use crate::backup::{SYNC_DOWN, SYNC_UP_PRE};
 use crate::error::{ErrorType, IntoResult};
+use crate::model::Changes;
 use crate::{Config, Result};
 use anyhow::anyhow;
 use tracing::{debug, info, warn};
 
 /// Gets data from the tiller Google sheet and persists it to the local datastore. Returns an info
 /// message that can be printed for the user.
-pub async fn sync_down(config: Config, mode: Mode) -> Result<Out<()>> {
+///
+/// `sync down` overwrites the local datastore: transactions are upserted from the sheet, and
+/// categories and AutoCat are replaced outright. Any local edit that has not been uploaded is lost.
+/// Unless `force` is set, the command therefore refuses to run when the datastore has been edited
+/// since it was last in step with the sheet.
+pub async fn sync_down(config: Config, mode: Mode, force: bool) -> Result<Out<()>> {
+    // Refuse to overwrite local edits that have never been uploaded.
+    let local_changes = local_changes(&config).await?;
+    match local_changes {
+        Some(changes) if !changes.is_empty() => {
+            if !force {
+                return Err(anyhow!(
+                    "The local datastore has changes that are not in the sheet: {changes}. \
+                     Running 'sync down' now would discard them. Run 'tiller sync up' first to \
+                     upload them, or use --force to discard them and overwrite with the sheet's \
+                     contents. Use 'tiller status' to see the local and remote state."
+                ))
+                .pub_result(ErrorType::Sync);
+            }
+            warn!("Discarding local changes and overwriting from the sheet (--force): {changes}");
+        }
+        _ => {}
+    }
+
     // Backup SQLite database before modifying
     let sqlite_backup = config
         .backup()
@@ -43,6 +67,29 @@ pub async fn sync_down(config: Config, mode: Mode) -> Result<Out<()>> {
         tiller_data.categories.data().len(),
         tiller_data.auto_cats.data().len()
     )))
+}
+
+/// Compares the local datastore against the last known state of the sheet.
+///
+/// Returns `None` when there is no snapshot to compare against, which means no sync has ever run
+/// and there is nothing local to protect.
+pub(crate) async fn local_changes(config: &Config) -> Result<Option<Changes>> {
+    let Some(last_synced) = config
+        .backup()
+        .load_latest_json(SYNC_DOWN)
+        .await
+        .pub_result(ErrorType::Internal)?
+    else {
+        return Ok(None);
+    };
+
+    let local = config
+        .db()
+        .get_tiller_data()
+        .await
+        .pub_result(ErrorType::Database)?;
+
+    Ok(Some(Changes::between(&last_synced, &local)))
 }
 
 /// Sends data from the local datastore to the Google sheet, returns a message that can be printed
@@ -100,15 +147,18 @@ pub async fn sync_up(
         Some(backup_data) => {
             // Compare current sheet with backup
             if current_sheet != backup_data {
+                let changes = Changes::between(&backup_data, &current_sheet);
                 if !force {
                     return Err(anyhow!(
-                        "Sheet has been modified since last sync down. \
-                         Run 'tiller sync down' first to merge changes, \
-                         or use --force to overwrite"
+                        "The sheet has been modified since the last sync down: {changes}. \
+                         Merge those changes first, or use --force to overwrite them with the \
+                         local datastore. Use 'tiller status' to see what differs."
                     ))
                     .pub_result(ErrorType::Sync);
                 }
-                warn!("Sheet differs from last sync-down, proceeding anyway (--force)");
+                warn!(
+                    "Overwriting sheet changes made since the last sync down (--force): {changes}"
+                );
             }
         }
     }
@@ -179,10 +229,21 @@ pub async fn sync_up(
         .pub_result(ErrorType::Sync)?;
 
     // Verification - re-fetch and compare against what we meant to write
-    let counts = tiller_client
+    let (counts, sheet_after_write) = tiller_client
         .verify_write(&db_data)
         .await
         .pub_result(ErrorType::Sync)?;
+
+    // Record the new baseline. Both sides now agree on this, so it is what the next `sync down`
+    // measures local edits against and what the next `sync up` measures remote edits against.
+    // Without it, every command after a successful upload would report the edits just uploaded as
+    // unsynced changes.
+    let baseline = config
+        .backup()
+        .save_json(SYNC_DOWN, &sheet_after_write)
+        .await
+        .pub_result(ErrorType::Internal)?;
+    debug!("Saved post-upload baseline to {}", baseline.display());
 
     // Preserve formulas if requested.
     let formula_summary = if preserve_formulas {
@@ -226,7 +287,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Verify SQLite backup was created
         let backup_files: Vec<_> = std::fs::read_dir(config.backups())
@@ -313,7 +376,9 @@ mod tests {
         let config = env.config();
 
         // First run sync_down to populate the database (precondition for sync_up)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Run sync_up - should create sync-up-pre backup
         sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
@@ -342,7 +407,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete all sync-down.*.json backup files
         for entry in std::fs::read_dir(config.backups()).unwrap() {
@@ -374,7 +441,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete all sync-down.*.json backup files
         for entry in std::fs::read_dir(config.backups()).unwrap() {
@@ -401,7 +470,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database and create backup
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Update the remote sheet with some change (row 1 is first data row, row 0 is header)
         let mut state = env.get_state();
@@ -439,7 +510,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database and create backup
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Update the remote sheet with some change (row 1 is first data row, row 0 is header)
         let mut state = env.get_state();
@@ -470,7 +543,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         // (e.g., if we have rows with original_order 0, 1, 2, deleting row 1 creates gap 0, 2)
@@ -502,7 +577,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         let db = config.db();
@@ -528,7 +605,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         let db = config.db();
@@ -554,7 +633,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Count existing SQLite backups (sync_down creates one)
         let backup_count_before: usize = std::fs::read_dir(config.backups())
@@ -597,7 +678,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -628,7 +711,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -697,7 +782,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -738,7 +825,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database (test data includes formulas)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Verify that formulas actually exist in the database
         let db_data = config.db().get_tiller_data().await.unwrap();
@@ -784,6 +873,118 @@ mod tests {
         env.set_state(state);
     }
 
+    /// The README and the MCP instructions used to say "always run sync_down first". Taken at face
+    /// value after local edits, that silently reverts every recategorization and deletes every
+    /// locally-added AutoCat rule. `sync down` now refuses rather than destroying the work.
+    ///
+    /// See https://github.com/webern/tiller-sync/issues/38
+    #[tokio::test]
+    async fn test_sync_down_refuses_to_discard_local_changes() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        // Recategorize a transaction, exactly the edit the reporter nearly lost.
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id.clone()], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        let result = sync_down(config.clone(), Mode::Testing, false).await;
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("1 transaction") && err.contains("sync up"),
+            "the error should name what would be lost and how to keep it, got: {err}"
+        );
+
+        // And the edit is still there.
+        let after = config.db()._get_transaction(&id).await.unwrap().unwrap();
+        assert_eq!(after.category, "Restaurants");
+    }
+
+    /// Discarding local work has to remain possible, just deliberate.
+    #[tokio::test]
+    async fn test_sync_down_discards_local_changes_with_force() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let original = data.transactions.data()[0].category.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id.clone()], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, true)
+            .await
+            .expect("--force should allow the overwrite");
+
+        let after = config.db()._get_transaction(&id).await.unwrap().unwrap();
+        assert_eq!(after.category, original, "the sheet's value should win");
+    }
+
+    /// A clean datastore must sync down without ceremony, or the guard would be worse than the
+    /// problem it solves.
+    #[tokio::test]
+    async fn test_sync_down_proceeds_when_nothing_changed_locally() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .expect("a second sync down with no local edits should just work");
+    }
+
+    /// The normal workflow is sync down, edit, sync up, sync down. That last step must not be
+    /// blocked by the edits that were just uploaded.
+    #[tokio::test]
+    async fn test_sync_down_after_sync_up_is_not_blocked() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .expect("after uploading, the datastore is in step and sync down should work");
+    }
+
     /// `transactions.transaction_id` is a primary key, and real sheets violate uniqueness: some
     /// feeds supply no ID at all, and malformed split markers repeat `split:[1]` across rows.
     /// `sync down` used to abort on the first such row with a bare UNIQUE constraint error.
@@ -805,7 +1006,7 @@ mod tests {
             ],
         );
 
-        let out = sync_down(config.clone(), Mode::Testing)
+        let out = sync_down(config.clone(), Mode::Testing, false)
             .await
             .expect("sync down must not abort on unusable Transaction IDs");
         assert!(out.message().contains("20 transactions"), "no row was lost");
@@ -843,7 +1044,9 @@ mod tests {
         let config = env.config();
 
         set_transaction_ids(&env, &[(0, ""), (1, "")]);
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let first: Vec<String> = config
             .db()
@@ -856,7 +1059,9 @@ mod tests {
             .map(|t| t.transaction_id.clone())
             .collect();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let second: Vec<String> = config
             .db()
@@ -882,7 +1087,9 @@ mod tests {
         let config = env.config();
 
         set_transaction_ids(&env, &[(0, ""), (1, "split:[1]"), (2, "split:[1]")]);
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let test_sheet = TestSheet::new(config.spreadsheet_id());
         test_sheet.clear_history();
@@ -925,7 +1132,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let db_data = config.db().get_tiller_data().await.unwrap();
         let expected_formulas = db_data.transactions.formulas().clone();
@@ -985,7 +1194,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let test_sheet = TestSheet::new(config.spreadsheet_id());
         test_sheet.clear_history();
@@ -1022,7 +1233,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
         let expected = config
             .db()
             .get_tiller_data()
@@ -1050,7 +1263,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete the last transaction, so the formula bound to the final row has no row left.
         let db = config.db();
@@ -1079,7 +1294,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database (this also seeds the TestSheet)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Capture original sheet state after sync_down (seed data is now loaded)
         let test_sheet = TestSheet::new(config.spreadsheet_id());

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,9 @@ pub async fn main_inner(args: Args) -> Result<()> {
                         .await?
                         .print()
                 }
-                UpDown::Down => commands::sync_down(config, mode).await?.print(),
+                UpDown::Down => commands::sync_down(config, mode, sync_args.force())
+                    .await?
+                    .print(),
             }
         }
 
@@ -133,6 +135,13 @@ pub async fn main_inner(args: Args) -> Result<()> {
         Command::Schema(schema_args) => {
             let config = Config::load(home).await?;
             commands::schema(config, schema_args.clone())
+                .await?
+                .print_data()?
+        }
+
+        Command::Status(status_args) => {
+            let config = Config::load(home).await?;
+            commands::status(config, mode, !status_args.local_only)
                 .await?
                 .print_data()?
         }

--- a/src/mcp/docs/INSTRUCTIONS.md
+++ b/src/mcp/docs/INSTRUCTIONS.md
@@ -34,13 +34,26 @@ Three types of data are synchronized:
 ## Recommended Workflow
 
 ```
-1. sync_down          <- Download latest data from Google Sheet
-2. [analyze/edit]     <- Work with local SQLite database
-3. sync_up            <- Upload changes back to Google Sheet
+1. sync_status        <- See where things stand
+2. sync_down          <- Download latest data from Google Sheet
+3. [analyze/edit]     <- Work with local SQLite database
+4. sync_up            <- Upload changes back to Google Sheet
 ```
 
-Always run `sync_down` before making local edits to ensure you have the latest data and to
-establish a baseline for conflict detection.
+Run `sync_down` at the **start** of a round of edits, to get fresh data and establish a baseline for
+conflict detection.
+
+**Never run `sync_down` between editing and `sync_up`.** It is not a refresh: transactions are
+upserted from the sheet, overwriting local field values, and Categories and AutoCat are deleted
+outright and replaced. Every recategorization and every locally-added AutoCat rule that has not been
+uploaded is gone.
+
+`sync_down` will refuse to run when the local database has unsynced changes, and will name what
+would be lost. Do not reach for `force=true` to get past that message: it means exactly what it
+says. Run `sync_up` first.
+
+To find out whether the sheet has changed without downloading it, use `sync_status`, which reads the
+sheet but writes nothing.
 
 ## Tool Reference
 
@@ -68,6 +81,22 @@ Downloads data from the Google Sheet to the local SQLite database.
   original_transaction_id IS NOT NULL`
 
 **Caution:** This overwrites local changes. The SQLite backup enables manual recovery if needed.
+
+### `sync_status`
+
+Reports what has changed on each side since the last sync. Modifies nothing.
+
+**Parameters:**
+
+| Parameter    | Type    | Default | Description                                              |
+|--------------|---------|---------|----------------------------------------------------------|
+| `local_only` | boolean | `false` | Report local changes only; do not read the Google Sheet  |
+
+**Returns:** `local` and `remote` counts of rows added, modified, and deleted per tab. `local` is
+what `sync_down` would discard; `remote` is what `sync_up` would overwrite.
+
+Comparison uses each row's sheet representation, so it reports what a sync can actually carry. A
+field that has no column in your sheet cannot be uploaded and is not counted.
 
 ### `sync_up`
 
@@ -143,6 +172,7 @@ Common errors and resolutions:
 
 | Error                              | Cause                               | Resolution                            |
 |------------------------------------|-------------------------------------|---------------------------------------|
+| "The local datastore has changes"  | Unsynced local edits                | Run `sync_up` first, or `force=true`  |
 | "Database has no transactions"     | Empty local database                | Run `sync_down` first                 |
 | "No sync-down backup found"        | Never ran `sync_down`               | Run `sync_down` or use `force=true`   |
 | "Sheet has been modified since..." | Remote changes detected             | Run `sync_down` or use `force=true`   |
@@ -266,7 +296,9 @@ Retrieves database schema information to help understand the data structure.
 
 ## Best Practices
 
-1. **Always sync down first** - Establishes baseline for conflict detection and ensures fresh data
+1. **Sync down at the start of a session, not in the middle of one** - It gives you fresh data and a
+   baseline for conflict detection, but it overwrites unsynced local edits. Use `sync_status` to
+   check the sheet mid-session instead
 2. **Use `formulas=ignore` when uncertain** - Safest option if you don't need formula preservation
 3. **Avoid `force=true` casually** - It bypasses safety checks; use only when intentional
 4. **Use `schema` before complex queries** - Understand the data structure before writing SQL

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2,8 +2,8 @@
 
 use crate::args::{
     DeleteAutoCatsArgs, DeleteCategoriesArgs, DeleteTransactionsArgs, InsertAutoCatArgs,
-    InsertCategoryArgs, InsertTransactionArgs, QueryArgs, SchemaArgs, UpdateAutoCatsArgs,
-    UpdateCategoriesArgs, UpdateTransactionsArgs,
+    InsertCategoryArgs, InsertTransactionArgs, QueryArgs, SchemaArgs, StatusArgs,
+    UpdateAutoCatsArgs, UpdateCategoriesArgs, UpdateTransactionsArgs,
 };
 use crate::commands::{self, FormulasMode};
 use crate::mcp::mcp_utils::tool_result;
@@ -15,6 +15,17 @@ use rmcp::{tool, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tracing::info;
+
+/// Parameters for the sync_down tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(title = "SyncDownParams")]
+pub struct SyncDownParams {
+    /// Discard local edits that have not been uploaded to the sheet. Without this, sync_down
+    /// refuses to run when the local database has unsynced changes, so that downloading cannot
+    /// silently destroy them.
+    #[serde(default)]
+    pub force: bool,
+}
 
 /// Parameters for the sync_up tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -70,14 +81,53 @@ impl TillerServer {
     ///
     /// # Caution
     ///
-    /// This operation overwrites local changes with sheet data. If you have local modifications
-    /// that haven't been synced up, they will be lost. The SQLite backup allows manual recovery
-    /// if needed.
+    /// This operation overwrites local changes with sheet data. To avoid discarding work, it
+    /// refuses to run when the local database has edits that have not been uploaded, and names
+    /// what would be lost. Run `sync_up` first to upload them, or set `force=true` to discard
+    /// them deliberately. The SQLite backup allows manual recovery if needed.
+    ///
+    /// Use `sync_status` to see whether the sheet has changed without downloading it.
+    ///
+    /// # Parameters
+    ///
+    /// - `force`: Discard local edits that have not been uploaded. Default `false`.
     #[tool]
-    async fn sync_down(&self) -> Result<CallToolResult, McpError> {
-        info!("MCP: sync_down called");
+    async fn sync_down(
+        &self,
+        Parameters(params): Parameters<SyncDownParams>,
+    ) -> Result<CallToolResult, McpError> {
+        info!("MCP: sync_down called with force={}", params.force);
         let config = (*self.config).clone();
-        let out = commands::sync_down(config, self.mode).await;
+        let out = commands::sync_down(config, self.mode, params.force).await;
+        tool_result(out)
+    }
+
+    /// Report what has changed in the local database and in the Google Sheet since the last sync,
+    /// without modifying either.
+    ///
+    /// Use this to decide which way to sync, and to check whether the sheet has moved on without
+    /// running `sync_down` (which would discard unsynced local edits).
+    ///
+    /// # Parameters
+    ///
+    /// - `local_only`: Skip reading the Google Sheet and report local changes only. Reading the
+    ///   sheet needs network access and valid authentication. Default `false`.
+    ///
+    /// # Returns
+    ///
+    /// - `synced_before`: false when no sync has ever run, in which case there is nothing to
+    ///   compare against.
+    /// - `local`: rows added, modified, and deleted locally since the last sync. `sync_down` would
+    ///   discard these.
+    /// - `remote`: the same counts for the Google Sheet. `sync_up` would overwrite these. Absent
+    ///   when `local_only` is true.
+    #[tool]
+    async fn sync_status(
+        &self,
+        Parameters(args): Parameters<StatusArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let config = (*self.config).clone();
+        let out = commands::status(config, self.mode, !args.local_only).await;
         tool_result(out)
     }
 

--- a/src/model/changes.rs
+++ b/src/model/changes.rs
@@ -1,0 +1,343 @@
+//! Comparing two `TillerData` snapshots.
+//!
+//! Used to answer two questions that look the same but are asked at different moments:
+//!
+//! - Before `sync down`: has the local datastore been edited since it was last in step with the
+//!   sheet? If so, downloading would overwrite those edits.
+//! - Before `sync up`: has the sheet been edited since it was last downloaded? If so, uploading
+//!   would overwrite those edits.
+//!
+//! See <https://github.com/webern/tiller-sync/issues/38>.
+
+use crate::model::items::Item;
+use crate::model::{AutoCats, Categories, TillerData, Transactions};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+
+/// How one tab differs between two snapshots.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TabChanges {
+    /// Rows present in the newer snapshot but not the older one.
+    pub added: usize,
+    /// Rows present in both, with at least one differing cell.
+    pub modified: usize,
+    /// Rows present in the older snapshot but not the newer one.
+    pub removed: usize,
+}
+
+impl TabChanges {
+    pub fn is_empty(&self) -> bool {
+        self.added == 0 && self.modified == 0 && self.removed == 0
+    }
+
+    fn total(&self) -> usize {
+        self.added + self.modified + self.removed
+    }
+}
+
+/// How two `TillerData` snapshots differ, tab by tab.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Changes {
+    /// Differences in the Transactions tab.
+    pub transactions: TabChanges,
+    /// Differences in the Categories tab.
+    pub categories: TabChanges,
+    /// Differences in the AutoCat tab.
+    pub auto_cats: TabChanges,
+}
+
+impl Changes {
+    /// Compares `newer` against `older`, describing what `newer` did to `older`.
+    pub(crate) fn between(older: &TillerData, newer: &TillerData) -> Self {
+        Self {
+            transactions: transaction_changes(&older.transactions, &newer.transactions),
+            categories: category_changes(&older.categories, &newer.categories),
+            auto_cats: auto_cat_changes(&older.auto_cats, &newer.auto_cats),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty() && self.categories.is_empty() && self.auto_cats.is_empty()
+    }
+}
+
+impl Display for Changes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            return write!(f, "no changes");
+        }
+
+        let mut parts = Vec::new();
+        for (name, tab) in [
+            ("transaction", self.transactions),
+            ("category", self.categories),
+            ("autocat rule", self.auto_cats),
+        ] {
+            if tab.is_empty() {
+                continue;
+            }
+            parts.push(format!(
+                "{} {name}{} ({} added, {} modified, {} deleted)",
+                tab.total(),
+                if tab.total() == 1 { "" } else { "s" },
+                tab.added,
+                tab.modified,
+                tab.removed
+            ));
+        }
+        write!(f, "{}", parts.join(", "))
+    }
+}
+
+/// Comparison uses each row's sheet representation rather than its in-memory fields.
+///
+/// A row's sheet representation is the canonical form of the data: it is exactly what a `sync up`
+/// would write and exactly what a `sync down` parsed. Comparing typed fields instead would report
+/// differences for values that round-trip through the database with a different but equivalent
+/// representation, which would make the check cry wolf and get ignored.
+fn rows<I>(items: &[I], headers: &[String]) -> Vec<Vec<String>>
+where
+    I: Item,
+{
+    items.iter().map(|item| item.to_row(headers)).collect()
+}
+
+/// The headers to compare a tab's rows across: the sheet's own columns.
+///
+/// Deliberately not "every field the model has". A field with no column in the sheet cannot be
+/// uploaded, so reporting an edit to it would produce a difference that no `sync up` could ever
+/// clear, and `sync down` would be blocked forever. The comparison measures what a sync can
+/// actually carry.
+///
+/// The unnamed column A that some sheets have is dropped for the opposite reason: it has no
+/// database column, so it reads back empty and would make every row look modified.
+fn headers_of(mapping: &crate::model::Mapping) -> Vec<String> {
+    mapping
+        .headers()
+        .iter()
+        .map(|h| h.as_ref().to_string())
+        .filter(|h| !h.is_empty())
+        .collect()
+}
+
+/// Compares two keyed tabs, where `key` extracts a stable identity for a row.
+fn keyed_changes(
+    older: Vec<(String, Vec<String>)>,
+    newer: Vec<(String, Vec<String>)>,
+) -> TabChanges {
+    let older: BTreeMap<String, Vec<String>> = older.into_iter().collect();
+    let newer: BTreeMap<String, Vec<String>> = newer.into_iter().collect();
+
+    let mut changes = TabChanges::default();
+    for (key, new_row) in &newer {
+        match older.get(key) {
+            None => changes.added += 1,
+            Some(old_row) if old_row != new_row => changes.modified += 1,
+            Some(_) => {}
+        }
+    }
+    changes.removed = older.keys().filter(|key| !newer.contains_key(*key)).count();
+    changes
+}
+
+fn transaction_changes(older: &Transactions, newer: &Transactions) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let keyed = |items: &Transactions| -> Vec<(String, Vec<String>)> {
+        items
+            .data()
+            .iter()
+            .map(|t| t.transaction_id.clone())
+            .zip(rows(items.data(), &headers))
+            .collect()
+    };
+    keyed_changes(keyed(older), keyed(newer))
+}
+
+fn category_changes(older: &Categories, newer: &Categories) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let keyed = |items: &Categories| -> Vec<(String, Vec<String>)> {
+        items
+            .data()
+            .iter()
+            .map(|c| c.category.clone())
+            .zip(rows(items.data(), &headers))
+            .collect()
+    };
+    keyed_changes(keyed(older), keyed(newer))
+}
+
+/// AutoCat rules have no stable identity: their primary key is a synthetic auto-increment that is
+/// reassigned on every `sync down`, because the whole tab is replaced. Rules are therefore compared
+/// as a multiset of their sheet rows, which reports a reordering as no change at all. That is the
+/// right answer here: the question is whether rules were gained or lost, and the sheet's own row
+/// order is not something the user edits meaningfully.
+fn auto_cat_changes(older: &AutoCats, newer: &AutoCats) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let counted = |items: &AutoCats| -> BTreeMap<Vec<String>, usize> {
+        let mut counts = BTreeMap::new();
+        for row in rows(items.data(), &headers) {
+            *counts.entry(row).or_default() += 1;
+        }
+        counts
+    };
+    let older = counted(older);
+    let newer = counted(newer);
+
+    let mut changes = TabChanges::default();
+    for (row, new_count) in &newer {
+        let old_count = older.get(row).copied().unwrap_or(0);
+        changes.added += new_count.saturating_sub(old_count);
+    }
+    for (row, old_count) in &older {
+        let new_count = newer.get(row).copied().unwrap_or(0);
+        changes.removed += old_count.saturating_sub(new_count);
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AutoCats, Categories, Transactions};
+
+    fn transactions(rows: &[(&str, &str, &str)]) -> Transactions {
+        let mut sheet = vec![vec![
+            "Transaction ID".to_string(),
+            "Date".to_string(),
+            "Amount".to_string(),
+            "Category".to_string(),
+        ]];
+        for (id, amount, category) in rows {
+            sheet.push(vec![
+                id.to_string(),
+                "2025-01-01".to_string(),
+                amount.to_string(),
+                category.to_string(),
+            ]);
+        }
+        Transactions::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn categories(names: &[&str]) -> Categories {
+        let mut sheet = vec![vec!["Category".to_string(), "Group".to_string()]];
+        for name in names {
+            sheet.push(vec![name.to_string(), "Everyday".to_string()]);
+        }
+        Categories::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn auto_cats(contains: &[&str]) -> AutoCats {
+        let mut sheet = vec![vec![
+            "Category".to_string(),
+            "Description Contains".to_string(),
+        ]];
+        for text in contains {
+            sheet.push(vec!["Groceries".to_string(), text.to_string()]);
+        }
+        AutoCats::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn data(
+        txns: &[(&str, &str, &str)],
+        cats: &[&str],
+        rules: &[&str],
+    ) -> crate::model::TillerData {
+        crate::model::TillerData {
+            transactions: transactions(txns),
+            categories: categories(cats),
+            auto_cats: auto_cats(rules),
+        }
+    }
+
+    #[test]
+    fn test_identical_data_has_no_changes() {
+        let a = data(&[("t1", "-1.00", "Food")], &["Food"], &["starbucks"]);
+        let b = data(&[("t1", "-1.00", "Food")], &["Food"], &["starbucks"]);
+        let changes = Changes::between(&a, &b);
+        assert!(changes.is_empty(), "got: {changes}");
+        assert_eq!(changes.to_string(), "no changes");
+    }
+
+    /// Recategorizing a transaction is the edit the reporter nearly lost.
+    #[test]
+    fn test_recategorizing_counts_as_a_modification() {
+        let before = data(&[("t1", "-1.00", "")], &["Food"], &[]);
+        let after = data(&[("t1", "-1.00", "Food")], &["Food"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.transactions.modified, 1);
+        assert_eq!(changes.transactions.added, 0);
+        assert_eq!(changes.transactions.removed, 0);
+        assert!(changes.categories.is_empty());
+    }
+
+    #[test]
+    fn test_added_and_removed_transactions() {
+        let before = data(&[("t1", "-1.00", "Food")], &["Food"], &[]);
+        let after = data(&[("t2", "-2.00", "Food")], &["Food"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.transactions.added, 1);
+        assert_eq!(changes.transactions.removed, 1);
+        assert_eq!(changes.transactions.modified, 0);
+    }
+
+    /// AutoCat rules added locally are the other thing the reporter nearly lost, and they have no
+    /// stable key to match on.
+    #[test]
+    fn test_added_autocat_rules() {
+        let before = data(&[], &["Groceries"], &["starbucks"]);
+        let after = data(&[], &["Groceries"], &["starbucks", "peets", "blue bottle"]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.auto_cats.added, 2);
+        assert_eq!(changes.auto_cats.removed, 0);
+    }
+
+    #[test]
+    fn test_removed_autocat_rules() {
+        let before = data(&[], &["Groceries"], &["starbucks", "peets"]);
+        let after = data(&[], &["Groceries"], &["starbucks"]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.auto_cats.removed, 1);
+        assert_eq!(changes.auto_cats.added, 0);
+    }
+
+    /// Reordering the AutoCat tab is not a change worth blocking a sync over.
+    #[test]
+    fn test_reordered_autocat_rules_are_not_changes() {
+        let before = data(&[], &["Groceries"], &["starbucks", "peets"]);
+        let after = data(&[], &["Groceries"], &["peets", "starbucks"]);
+        let changes = Changes::between(&before, &after);
+
+        assert!(changes.auto_cats.is_empty(), "got: {changes}");
+    }
+
+    #[test]
+    fn test_category_changes() {
+        let before = data(&[], &["Food", "Gas"], &[]);
+        let after = data(&[], &["Food", "Fuel"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.categories.added, 1);
+        assert_eq!(changes.categories.removed, 1);
+    }
+
+    #[test]
+    fn test_display_summarizes_every_tab() {
+        let before = data(&[("t1", "-1.00", "")], &["Food"], &[]);
+        let after = data(
+            &[("t1", "-1.00", "Food"), ("t2", "-2.00", "Food")],
+            &["Food", "Gas"],
+            &["shell"],
+        );
+        let summary = Changes::between(&before, &after).to_string();
+
+        assert!(summary.contains("2 transactions"), "got: {summary}");
+        assert!(summary.contains("1 category"), "got: {summary}");
+        assert!(summary.contains("1 autocat rule"), "got: {summary}");
+    }
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,6 +2,7 @@
 mod amount;
 mod auto_cat;
 mod category;
+mod changes;
 mod date;
 mod items;
 mod mapping;
@@ -12,6 +13,7 @@ mod transaction_ids;
 pub use amount::{Amount, AmountFormat};
 pub use auto_cat::{AutoCat, AutoCatUpdates, AutoCats};
 pub use category::{Categories, Category, CategoryUpdates};
+pub use changes::{Changes, TabChanges};
 pub use date::Date;
 pub(crate) use date::{DateFromOpt, DateFromOptStr, DateToSheetStr};
 pub(crate) use items::Item;


### PR DESCRIPTION
Fixes #38.

This is filed as a docs issue, but the advice was destructive, so it seemed worth closing the footgun as well as the wording. All three of the reporter's suggestions are implemented.

### 1. The advice is scoped

`sync_down` belongs at the **start** of a round of edits, never between editing and `sync_up`. The docs now say what it actually does to unsynced work — transactions overwritten from the sheet, Categories and AutoCat deleted outright and replaced — rather than describing it as a refresh. Fixed in the README, `INSTRUCTIONS.md` (both the workflow section and Best Practice #1), and `DESIGN.md`.

### 2. `sync down` detects local divergence and requires `--force`

It now refuses when the datastore has changes that are not in the sheet, and says what would be lost:

```
Sync error: The local datastore has changes that are not in the sheet: 1 transaction
(0 added, 1 modified, 0 deleted). Running 'sync down' now would discard them. Run
'tiller sync up' first to upload them, or use --force to discard them and overwrite
with the sheet's contents. Use 'tiller status' to see the local and remote state.
```

The tricky part is not the check, it's not becoming an obstacle. `sync up` now records a new baseline after a successful upload, taken from the sheet as re-read during verification (`verify_write` already fetched it and threw it away). Without that, the ordinary down → edit → up → down cycle would be permanently blocked by the edits that had just been uploaded. There's a test for exactly that.

### 3. `tiller status` / MCP `sync_status`

Reports what has changed on each side since the last sync, modifying neither. This is the supported way to check for remote drift without a `sync down`.

```bash
tiller status               # local and remote
tiller status --local-only  # no network, no auth needed
```

### How rows are compared

Rows are compared by their **sheet representation** — the same strings a `sync up` would write — rather than by their typed fields. Comparing typed fields would report differences for values that round-trip through the database in a different but equivalent representation (an `Amount` through `f64`, a `Date` through its string form), and a check that cries wolf gets ignored, which would defeat the point.

Two consequences, both deliberate and both documented:

- **A field with no column in the sheet is not compared.** I tried the other way first and it was clearly wrong: such a field can never be uploaded, so a difference in it could never be cleared by a `sync up`, and `sync down` would be blocked forever. The comparison measures what a sync can actually carry.
- **The unnamed column A is not compared.** It has no database column (the `no_name` gap noted in #45), so it reads back empty and would make every row look modified.

Transactions and categories are keyed by primary key. AutoCat rules have no stable identity — the synthetic key is reassigned on every `sync down`, since the whole tab is replaced — so they're compared as a multiset of rows, which correctly treats a reordering as no change.

`sync up`'s existing conflict message now names the counts too, which `DESIGN.md` step 3f had always called for and the code never did.

### Verification

12 new tests: 8 on the comparison itself (including the two edits the reporter nearly lost — a recategorization and added AutoCat rules), and 4 on the `sync down` guard (refuses, `--force` overrides, a clean datastore is unaffected, and down-after-up is not blocked). Plus 5 on `status`.

Checked end-to-end against a real binary in test mode: clean status → local edit → status reports it → `sync down` refuses → `sync up` → `sync down` succeeds.

`cargo fmt --check`, `cargo clippy -- -D warnings`, and `cargo test` (233 tests) all pass.