### PR TITLE
fix: keep the OAuth browser flow out of MCP startup (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `tiller auth` refuses to start unless stdin is a terminal. It opens a browser and waits for a
+  person, so run from a script or an AI agent's shell it would pop a browser at the user and then
+  hang. `tiller auth --verify` is unaffected and remains scriptable. [#34]
+- When stored Google credentials do not work, the error now says that a person has to run
+  `tiller auth` in a terminal, and that an assistant should ask the user rather than run it. [#34]
 - Documentation no longer says to "always sync down first". Taken at face value after making local
   edits, that advice reverts every local change. It is now scoped to the start of a round of edits.
   [#38]
@@ -126,6 +131,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!-- Issues -->
 [#24]: https://github.com/webern/tiller-sync/issues/24
 [#28]: https://github.com/webern/tiller-sync/issues/28
+[#34]: https://github.com/webern/tiller-sync/issues/34
 [#35]: https://github.com/webern/tiller-sync/issues/35
 [#36]: https://github.com/webern/tiller-sync/issues/36
 [#37]: https://github.com/webern/tiller-sync/issues/37

--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ With Claude Code and Tiller Sync, you can:
 
 ## Troubleshooting
 
+### "'tiller auth' has to be run by a person at a terminal"
+
+`tiller auth` opens a browser and waits for you to authorize in it, so it cannot run from a script,
+a background process, or an AI agent's shell. Open a terminal and run it yourself. To check existing
+credentials without any browser interaction, use `tiller auth --verify`, which is safe to script.
+
 ### "Access token expired" or "Invalid credentials"
 
 Your OAuth token may have expired. Refresh it with:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,6 +77,19 @@ In detail, the workflow of `tiller auth` is as follows:
 **Important**: `tiller auth` is the ONLY operation that initiates this interactive workflow. All
 other operations should be scriptable.
 
+`tiller auth` additionally refuses to start unless stdin is a terminal. The flow opens a browser and
+then blocks until a person authorizes in it, so started from a script, a background process, or an
+AI agent's shell it pops a browser window at the user without warning and then hangs. That is what
+re-authorization "happening on its own" looks like from the user's side. There is no legitimate
+non-interactive use of the flow, since it cannot complete without a human; `tiller auth --verify` is
+the scriptable command.
+
+Credentials are read only when an operation actually needs the Google API, in `api::sheet()`.
+Starting the CLI or the MCP server does not touch them, so neither a `tiller mcp` launch nor an MCP
+client's `initialize` handshake can trigger anything auth-related. When the stored credentials do
+not work, the error says that a person has to run `tiller auth` in a terminal and that an assistant
+should ask rather than run it.
+
 #### `tiller auth --verify`
 
 To check authentication, and refresh the token, users can call `tiller auth --verify`. The

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,7 @@ pub(super) use sheet_test_client::TestSheet;
 use std::env::VarError;
 
 use crate::error::{ErrorType, IntoResult, Res};
+use anyhow::Context;
 #[cfg(test)]
 pub(super) use sheet_test_client::{SheetCall, TestSheetState};
 
@@ -78,10 +79,20 @@ impl Mode {
 pub async fn sheet(config: Config, mode: Mode) -> Result<Box<dyn Sheet>> {
     let sheet_client: Box<dyn Sheet> = match mode {
         Mode::Google => {
+            // Credentials are only read here, when an operation actually needs the Google API.
+            // Nothing about starting the CLI or the MCP server touches them, and nothing outside
+            // `tiller auth` can start the interactive OAuth flow.
             let token_provider =
                 TokenProvider::load(config.client_secret_path(), config.token_path())
                     .await
-                    .pub_result(ErrorType::Config)?;
+                    .context(
+                        "Could not use the stored Google credentials. Someone needs to run \
+                         'tiller auth' in a terminal to re-authorize; it opens a browser and waits \
+                         for a person to approve, so it cannot be run unattended. If you are an \
+                         assistant working on the user's behalf, ask them to run it rather than \
+                         running it yourself.",
+                    )
+                    .pub_result(ErrorType::Auth)?;
             Box::new(
                 GoogleSheet::new(config.clone(), token_provider)
                     .await

--- a/src/api/oauth.rs
+++ b/src/api/oauth.rs
@@ -53,6 +53,8 @@ impl TokenProvider {
         P1: Into<PathBuf>,
         P2: Into<PathBuf>,
     {
+        require_a_terminal()?;
+
         let secret_path = secret.into();
         let token_path = token.into();
 
@@ -234,6 +236,33 @@ impl TokenProvider {
         self.token.save().await?;
         Ok(self.token())
     }
+}
+
+/// Refuses to start the interactive OAuth flow unless a person is at the keyboard.
+///
+/// The flow opens a browser and then blocks until the user authorizes in it. Started from anywhere
+/// else - a script, a CI job, or an AI agent's shell - it pops a browser window at the user without
+/// warning and then hangs until something times out. That is what an agent reaching for
+/// `tiller auth` after seeing an expired-token error looks like from the user's side, and it is
+/// what makes re-authorization appear to happen on its own.
+///
+/// There is no legitimate non-interactive use of this flow: it cannot complete without a human in a
+/// browser. `tiller auth --verify` is the scriptable command.
+///
+/// See <https://github.com/webern/tiller-sync/issues/34>.
+fn require_a_terminal() -> Res<()> {
+    use std::io::IsTerminal;
+
+    if std::io::stdin().is_terminal() {
+        return Ok(());
+    }
+
+    bail!(
+        "'tiller auth' has to be run by a person at a terminal. It opens a browser and waits for \
+         you to authorize there, so it cannot complete when started by a script, a background \
+         process, or an AI agent. Open a terminal and run 'tiller auth' yourself.\n\n\
+         To check existing credentials without any of that, use 'tiller auth --verify'."
+    )
 }
 
 /// Async HTTP client for OAuth2 requests using reqwest
@@ -437,5 +466,47 @@ async fn receive_oauth_callback(listener: TcpListener, expected_csrf: CsrfToken)
         Some(Ok(code)) => Ok(code),
         Some(Err(e)) => Err(e),
         None => bail!("Failed to receive authorization code"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests do not run with a terminal on stdin, which is the same situation an agent's shell or a
+    /// background process is in. The interactive flow must refuse rather than opening a browser at
+    /// the user and then blocking.
+    ///
+    /// See https://github.com/webern/tiller-sync/issues/34
+    #[tokio::test]
+    async fn test_interactive_auth_refuses_without_a_terminal() {
+        let result = TokenProvider::initialize("client_secret.json", "token.json").await;
+
+        let err = result
+            .expect_err("the interactive flow must not start without a terminal")
+            .to_string();
+        assert!(
+            err.contains("terminal"),
+            "the error should explain that a person has to run this, got: {err}"
+        );
+        assert!(
+            err.contains("--verify"),
+            "the error should point at the scriptable alternative, got: {err}"
+        );
+    }
+
+    /// The guard has to come before anything else, or a missing credentials file would be reported
+    /// instead and the real problem would be hidden.
+    #[tokio::test]
+    async fn test_terminal_check_precedes_reading_credentials() {
+        let result =
+            TokenProvider::initialize("/nonexistent/client_secret.json", "/nonexistent/token.json")
+                .await;
+
+        let err = result.expect_err("expected an error").to_string();
+        assert!(
+            err.contains("terminal"),
+            "the terminal check should run first, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
Fixes #34. Based on #52.

## Problem

Starting an agent session could pop a Google authorization browser window at the user and then hang, with no action on their part beyond launching the agent.

The MCP server itself is not the cause. `TokenProvider::initialize` — the only function that opens a browser — is reachable from exactly one place, `commands::auth`. Credentials are read in `api::sheet()`, which runs only when an operation needs the Google API. Launching `tiller mcp`, loading `Config`, opening the database, and the MCP `initialize` handshake touch none of it, and `TokenProvider::load` and `refresh` are non-interactive by construction.

What reached it was an agent, via a three-step sequence at the start of a session:

1. `INTRO.md` instructed the agent that it **MUST** call `initialize_service` before anything else, so its first action was to interact with the server.
2. That returned `INSTRUCTIONS.md`, whose first best practice was "always sync down first".
3. `sync_down` hits the Google API. With an expired token it fails — and an agent that has just been told to initialize the service reasonably concludes the remedy is `tiller auth`, and runs it in a shell.

`tiller auth` then calls `open` with the authorization URL and blocks waiting for the callback. Steps 1 and 2 are removed in #52; this PR closes step 3.

## Change

`tiller auth` refuses to start unless stdin is a terminal:

```
$ tiller auth   # from a script or an agent's shell
Auth error: 'tiller auth' has to be run by a person at a terminal. It opens a browser
and waits for you to authorize there, so it cannot complete when started by a script, a
background process, or an AI agent. Open a terminal and run 'tiller auth' yourself.

To check existing credentials without any of that, use 'tiller auth --verify'.
```

There is no override flag, deliberately: the flow cannot complete without a person in a browser, so no non-interactive use of it can succeed. `tiller auth --verify` already covers the scriptable case and is untouched.

The terminal check runs before anything else in `initialize`, so a missing credentials file cannot mask the real problem.

The credential-failure error is also reworded, since the sequence begins with one. It now states that a person has to run `tiller auth` in a terminal, and that an assistant should ask the user rather than run it. That reaches the agent through the MCP tool result, and `INTRO.md` says the same up front.

## Tests

Two tests, run without a terminal on stdin — the same condition an agent's shell is in, so they assert the real behavior rather than simulating it. One covers the refusal; the other covers ordering, that the terminal check precedes reading credentials.

Checked against a real binary: `tiller auth` refuses from a non-terminal; `tiller auth --verify` still fails on the credentials rather than on the terminal check.

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (230 tests) pass.