### PR TITLE
fix: make sync usable against real sheets, stop it destroying local edits, keep OAuth out of startup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,12 +103,6 @@ The MCP server has two important documentation files in `src/mcp/docs/`:
 - **`INSTRUCTIONS.md`**: In-depth usage guide, returned by the optional `instructions` tool. It
   contains detailed information about workflows, parameters, and best practices.
 
-Calling `instructions` is NOT a precondition for using the other tools. An earlier design gated
-every tool behind an `initialize_service` call; that was removed because forcing a help lookup
-before any real work is possible makes the server behave unlike every other MCP server. Do not
-reintroduce a gate. Anything an agent must know in order to use a tool safely belongs in that tool's
-own doc comment.
-
 ### Restrictive use of Pub
 
 `pub` functions in this library should be restricted to these modules: `commands`, `args`, `model`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,10 +98,16 @@ For dead code warnings during incremental development:
 The MCP server has two important documentation files in `src/mcp/docs/`:
 
 - **`INTRO.md`**: Brief description shown to the AI client upon MCP server initialization (via
-  `ServerInfo.instructions`). Keep this concise.
-- **`INSTRUCTIONS.md`**: In-depth usage guide that the agent must read before using tools. This is
-  returned by the `initialize_service` tool and contains detailed information about workflows,
-  parameters, and best practices.
+  `ServerInfo.instructions`). Keep this concise: every client pays for it in context on every
+  session, whether or not tiller is used.
+- **`INSTRUCTIONS.md`**: In-depth usage guide, returned by the optional `instructions` tool. It
+  contains detailed information about workflows, parameters, and best practices.
+
+Calling `instructions` is NOT a precondition for using the other tools. An earlier design gated
+every tool behind an `initialize_service` call; that was removed because forcing a help lookup
+before any real work is possible makes the server behave unlike every other MCP server. Do not
+reintroduce a gate. Anything an agent must know in order to use a tool safely belongs in that tool's
+own doc comment.
 
 ### Restrictive use of Pub
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- MCP tools no longer require an `initialize_service` call before they can be used. The tool is
+  replaced by an optional `instructions` tool that returns the same in-depth guide, and the
+  server's `ServerInfo.instructions` is now a concise orientation.
 - Update dependencies, including major-version upgrades of `rmcp` (0.12 to 3) and `sqlx` (0.8 to
   0.9)
+
+### Removed
+
+- The `initialize_service` MCP tool. Use `instructions` instead; it is no longer a precondition for
+  calling anything else.
 
 ## [v0.2.1] - 2025-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,21 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- `tiller status` (MCP: `sync_status`) reports what has changed locally and in the sheet since the
+  last sync, without modifying either. This makes it possible to check for remote changes without
+  running `sync down`. [#38]
+- `sync down` now refuses to run when the local datastore has changes that have not been uploaded,
+  naming what would be lost. `--force` discards them deliberately. [#38]
 - `sync up` reports how many formulas were written and reads the sheet back to check that they
   landed, warning if the counts disagree. [#35]
 
 ### Changed
 
+- Documentation no longer says to "always sync down first". Taken at face value after making local
+  edits, that advice reverts every local change. It is now scoped to the start of a round of edits.
+  [#38]
+- `sync up`'s conflict message names how many rows were added, modified, and deleted in the sheet
+  since the last download, instead of only saying that it changed.
 - MCP tools no longer require an `initialize_service` call before they can be used. The tool is
   replaced by an optional `instructions` tool that returns the same in-depth guide, and the
   server's `ServerInfo.instructions` is now a concise orientation.
@@ -119,5 +129,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [#35]: https://github.com/webern/tiller-sync/issues/35
 [#36]: https://github.com/webern/tiller-sync/issues/36
 [#37]: https://github.com/webern/tiller-sync/issues/37
+[#38]: https://github.com/webern/tiller-sync/issues/38
 [#40]: https://github.com/webern/tiller-sync/issues/40
 [#41]: https://github.com/webern/tiller-sync/issues/41

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- `tiller auth` refuses to start unless stdin is a terminal. It opens a browser and waits for a
+  person, so run from a script or an AI agent's shell it would pop a browser at the user and then
+  hang. `tiller auth --verify` is unaffected and remains scriptable. [#34]
+- When stored Google credentials do not work, the error now says that a person has to run
+  `tiller auth` in a terminal, and that an assistant should ask the user rather than run it. [#34]
 - Documentation no longer says to "always sync down first". Taken at face value after making local
   edits, that advice reverts every local change. It is now scoped to the start of a round of edits.
   [#38]
@@ -126,6 +131,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 <!-- Issues -->
 [#24]: https://github.com/webern/tiller-sync/issues/24
 [#28]: https://github.com/webern/tiller-sync/issues/28
+[#34]: https://github.com/webern/tiller-sync/issues/34
 [#35]: https://github.com/webern/tiller-sync/issues/35
 [#36]: https://github.com/webern/tiller-sync/issues/36
 [#37]: https://github.com/webern/tiller-sync/issues/37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   [#36]
 - `--other-field` on the `insert` and `update` subcommands is now optional and no longer panics when
   supplied. Repeating it adds one custom column per occurrence. [#41]
-- Negative amounts can now be given as `--amount -12.34` instead of only `--amount=-12.34`.
+- Negative amounts can now be given as `--amount -12.34` instead of only `--amount=-12.34`. [#41]
 - Updating a transaction no longer clears its `original_order`, which had caused updated rows to be
   written to the bottom of the Transactions tab on the next `sync up`. [#40]
 - `sync up --formulas preserve` now actually writes formulas back to the sheet. It had been
@@ -27,9 +27,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `sync up` reports how many formulas were written and reads the sheet back to check that they
   landed, warning if the counts disagree. [#35]
-- Negative amounts can now be given as `--amount -12.34` instead of only `--amount=-12.34`. [#41]
-- `--other-field` on the `insert` and `update` subcommands is now optional and no longer panics when
-  supplied. Repeating it adds one custom column per occurrence. [#41]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `sync up --formulas preserve` now actually writes formulas back to the sheet. It had been
   identical to `--formulas ignore`, silently replacing every formula with its last computed value
   while reporting success. [#35]
+- `sync down` no longer aborts on rows whose `Transaction ID` is blank or duplicated, which is
+  common in real sheets. Such rows are given a stable surrogate `user-` ID for local use, and the
+  sheet's own value is written back unchanged on `sync up`. [#37]
 
 ### Added
 
@@ -110,5 +113,6 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 [#28]: https://github.com/webern/tiller-sync/issues/28
 [#35]: https://github.com/webern/tiller-sync/issues/35
 [#36]: https://github.com/webern/tiller-sync/issues/36
+[#37]: https://github.com/webern/tiller-sync/issues/37
 [#40]: https://github.com/webern/tiller-sync/issues/40
 [#41]: https://github.com/webern/tiller-sync/issues/41

--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ With Claude Code and Tiller Sync, you can:
 
 ## Troubleshooting
 
+### "'tiller auth' has to be run by a person at a terminal"
+
+`tiller auth` opens a browser and waits for you to authorize in it, so it cannot run from a script,
+a background process, or an AI agent's shell. Open a terminal and run it yourself. To check existing
+credentials without any browser interaction, use `tiller auth --verify`, which is safe to script.
+
 ### "Access token expired" or "Invalid credentials"
 
 Your OAuth token may have expired. Refresh it with:

--- a/README.md
+++ b/README.md
@@ -161,6 +161,13 @@ This will:
 - Download Transactions, Categories, and AutoCat data from your Tiller sheet
 - Create a backup of the previous database state
 
+Run this at the **start** of a round of edits, never between editing and `tiller sync up`. It is not
+a refresh: transactions are overwritten from the sheet, and Categories and AutoCat are replaced
+outright, so any local change you have not uploaded is lost. It refuses to run when the local
+database has unsynced changes, and names what would be lost; `--force` discards them deliberately.
+
+To check whether the sheet has changed without downloading it, use `tiller status`.
+
 ### Sync Local Changes to Google Sheets
 
 Upload local changes back to your Tiller sheet:
@@ -173,6 +180,19 @@ This will:
 
 - Update your Google Sheets with any changes made to the local database
 - Create a backup before syncing
+
+### See What Has Changed
+
+```bash
+# What has changed locally, and what has changed in the sheet, since the last sync
+tiller status
+
+# Local changes only; does not read the sheet
+tiller status --local-only
+```
+
+Neither side is modified. Use this to check whether your local edits still need uploading, or
+whether the sheet has moved on, without running a sync in either direction.
 
 ### Query Data
 
@@ -261,6 +281,7 @@ claude mcp add tiller -- tiller --tiller-home /path/to/your/tiller mcp
 Once configured, Claude Code can use the following tools:
 
 - **sync_down** / **sync_up**: Sync data between your Google Sheet and local database
+- **sync_status**: See what has changed on each side since the last sync, without modifying either
 - **query**: Execute SQL queries against your local database
 - **schema**: View database structure and column descriptions
 - **insert_transaction** / **update_transactions** / **delete_transactions**: Manage transactions

--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ Once configured, Claude Code can use the following tools:
 - **insert_transaction** / **update_transactions** / **delete_transactions**: Manage transactions
 - **insert_category** / **update_categories** / **delete_categories**: Manage categories
 - **insert_autocat** / **update_autocats** / **delete_autocats**: Manage AutoCat rules
+- **instructions**: The in-depth usage guide, if the agent wants more than each tool's own
+  description
 
 ### Example Use Cases
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -726,6 +726,16 @@ MCP tools wrap CLI commands with equivalent parameters:
 - **sync_down**: Downloads data from Google Sheet to local SQLite. No parameters.
 - **sync_up**: Uploads data from local SQLite to Google Sheet. Parameters: `force` (bool),
   `formulas` (enum: unknown, preserve, ignore).
+- **instructions**: Returns the in-depth usage guide (`src/mcp/docs/INSTRUCTIONS.md`). No
+  parameters.
+
+Every tool is callable straight away. `instructions` is a convenience, not a precondition:
+each tool documents its own parameters and behavior in its description, and the concise
+orientation in `ServerInfo.instructions` covers the rest.
+
+**Historical note:** an earlier design gated every tool behind an `initialize_service` call, on the
+theory that agents treat `ServerInfo.instructions` as optional reading. Forcing a help lookup before
+any real work is possible makes the server behave unlike every other MCP server, and it was removed.
 
 ### Tool Responses
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -733,10 +733,6 @@ Every tool is callable straight away. `instructions` is a convenience, not a pre
 each tool documents its own parameters and behavior in its description, and the concise
 orientation in `ServerInfo.instructions` covers the rest.
 
-**Historical note:** an earlier design gated every tool behind an `initialize_service` call, on the
-theory that agents treat `ServerInfo.instructions` as optional reading. Forcing a help lookup before
-any real work is possible makes the server behave unlike every other MCP server, and it was removed.
-
 ### Tool Responses
 
 For `sync up` and `sync down` tools we return minimal responses: success/failure status and a

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -77,6 +77,19 @@ In detail, the workflow of `tiller auth` is as follows:
 **Important**: `tiller auth` is the ONLY operation that initiates this interactive workflow. All
 other operations should be scriptable.
 
+`tiller auth` additionally refuses to start unless stdin is a terminal. The flow opens a browser and
+then blocks until a person authorizes in it, so started from a script, a background process, or an
+AI agent's shell it pops a browser window at the user without warning and then hangs. That is what
+re-authorization "happening on its own" looks like from the user's side. There is no legitimate
+non-interactive use of the flow, since it cannot complete without a human; `tiller auth --verify` is
+the scriptable command.
+
+Credentials are read only when an operation actually needs the Google API, in `api::sheet()`.
+Starting the CLI or the MCP server does not touch them, so neither a `tiller mcp` launch nor an MCP
+client's `initialize` handshake can trigger anything auth-related. When the stored credentials do
+not work, the error says that a person has to run `tiller auth` in a terminal and that an assistant
+should ask rather than run it.
+
 #### `tiller auth --verify`
 
 To check authentication, and refresh the token, users can call `tiller auth --verify`. The

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -505,6 +505,39 @@ struct TransactionId {
 - We will implement a `Default` function for this using the `uuid` crate that creates a `Local` ID.
 - We will implement Serialize and Deserialize
 
+##### Unusable IDs in real sheets
+
+`transactions.transaction_id` is the primary key, but real Tiller sheets routinely contain rows
+whose `Transaction ID` cannot serve as one:
+
+- **Blank.** Some feeds supply no ID at all. Apple Card is the well-known example and can account
+  for hundreds of rows in an ordinary sheet.
+- **Duplicated.** Malformed split markers such as `split:[1]` and `split:[2]` appear verbatim in the
+  column on every split row instead of referencing the parent transaction's ID.
+
+Neither case means the row is corrupt, so `sync down` does not refuse them. Every affected row is
+given a surrogate `user-` ID, and the sheet's own value is stored in `original_transaction_id`. That
+value is what `get_by_header` returns for the `Transaction ID` column, so `sync up` writes it back
+and the Transactions tab round-trips unchanged. A warning reports how many rows were affected and
+how to list them.
+
+A surrogate has to be **stable** across syncs, because `sync down` upserts on `transaction_id`: an
+ID that changed between syncs would make the row look deleted and re-added, discarding local edits.
+The surrogate is therefore `user-` followed by a 64-bit FNV-1a hash of the row's bank-supplied
+content — the sheet's ID value, date, amount, description, full description, account, and
+institution — plus the occurrence number within a group of otherwise-identical rows.
+
+- Position is deliberately **not** part of the hash: inserting a row above would re-key everything
+  below it.
+- Locally-editable fields such as `category` and `note` are deliberately **not** part of the hash:
+  categorizing a row would otherwise re-key it.
+- The amount contributes its **numeric value**, not its rendered string. An `Amount` keeps the
+  formatting it was parsed from, and reformatting the Amount column in the sheet does not change
+  what the row is.
+- FNV-1a is written out in `src/model/transaction_ids.rs` rather than taken from
+  `std::hash::DefaultHasher`, whose algorithm is explicitly allowed to change between Rust releases.
+  These hashes are persisted as primary keys, so the algorithm is part of the on-disk format.
+
 ## Database Schema
 
 The SQLite database contains the following tables. See `src/db/migrations/` for exact DDL.
@@ -513,10 +546,13 @@ The SQLite database contains the following tables. See `src/db/migrations/` for 
 
 **transactions** - Financial transactions from the Tiller Transactions sheet.
 
-- Primary key: `transaction_id` (Tiller-assigned or `user-` prefixed local UUID)
+- Primary key: `transaction_id` (Tiller-assigned, or a `user-` prefixed local ID)
 - Indexed on: `date`, `account`, `category`, `description`
 - Foreign key: `category` references `categories(category)` with `ON UPDATE CASCADE ON DELETE
   RESTRICT`
+- `original_transaction_id TEXT` - The sheet's own `Transaction ID` value, kept only when it could
+  not serve as a primary key because it was blank or duplicated. NULL otherwise. See Unusable IDs in
+  real sheets.
 
 **categories** - Budget categories from the Tiller Categories sheet.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -101,6 +101,12 @@ Downloading changes from the Tiller Google Sheet:
 tiller sync down
 ```
 
+Seeing where the two sides stand, without modifying either:
+
+```bash
+tiller status
+```
+
 ### MCP
 
 The `tiller mcp` command launches an MCP server. See the dedicated MCP section later in this
@@ -264,6 +270,9 @@ Generated after successful OAuth consent flow. The file contains:
 
 During the `tiller sync down` call, the following happens.
 
+- The local datastore is compared against the last state both sides agreed on. If it has changes
+  that are not in the sheet, the command errors out and names what would be lost, since downloading
+  would discard them. `--force` proceeds anyway.
 - If the datastore does not exist, it is created.
 - A backup of the SQLite database is created.
 - If more than `backup_copies` of the SQLite database exist, the extras are deleted.
@@ -451,16 +460,64 @@ tiller sync down
 
 # 2. Make local edits in SQLite
 
-# 3. Upload local changes back to sheet
+# 3. See where things stand before syncing
+tiller status
+
+# 4. Upload local changes back to sheet
 tiller sync up
 ```
 
-**Forcing overwrites** (when local is authoritative):
+`sync down` belongs at the *start* of a round of edits, never between editing and `sync up`. It is
+not a refresh: transactions are upserted from the sheet, overwriting local field values, and
+Categories and AutoCat are deleted outright and replaced. `tiller status` is the way to check
+whether the sheet has moved on without downloading it.
+
+**Forcing overwrites** (when one side is authoritative):
 
 ```bash
-# Force upload despite remote changes
+# Discard local edits and take the sheet's contents
+tiller sync down --force
+
+# Overwrite sheet changes made since the last download
 tiller sync up --force
 ```
+
+### Change Detection
+
+Both sync directions and `tiller status` compare against the most recent `sync-down.*.json`
+snapshot, which records the last state both sides agreed on. `sync up` writes a fresh snapshot after
+a successful upload, from the sheet as re-read during verification; without that, every command
+after an upload would keep reporting the edits just uploaded as unsynced.
+
+Rows are compared by their **sheet representation** - the same strings a `sync up` would write.
+Comparing typed fields instead would report differences for values that round-trip through the
+database with a different but equivalent representation, and a check that cries wolf gets ignored.
+Two consequences follow:
+
+- A field with no column in the sheet is not compared. It cannot be uploaded, so a difference in it
+  could never be cleared by a `sync up` and would block `sync down` forever.
+- The unnamed column A that some sheets carry is not compared. It has no database column, so it
+  reads back empty and would make every row look modified.
+
+Transactions and categories are keyed by their primary key. AutoCat rules have no stable identity -
+their synthetic key is reassigned on every `sync down`, since the whole tab is replaced - so they are
+compared as a multiset of rows. Reordering the AutoCat tab is therefore not reported as a change.
+
+### `tiller status`
+
+Reports what has changed on each side since the last sync, modifying neither.
+
+```bash
+# Local and remote changes
+tiller status
+
+# Local changes only; does not read the sheet, so it needs no network or authentication
+tiller status --local-only
+```
+
+Its purpose is to make the two questions answerable separately: "have my local edits been
+uploaded?" and "has the sheet changed since I last downloaded?". The second used to require a
+`sync down`, which is exactly the operation that discards unsynced local edits.
 
 ### Row IDs
 
@@ -815,6 +872,8 @@ tiller schema --include-metadata
 
 Two new MCP tools wrap the CLI commands:
 
+- **sync_status**: Reports local and remote changes since the last sync. Parameters: `local_only`
+  (optional, defaults to false).
 - **query**: Executes arbitrary read-only SQL. Parameters: `sql` (required), `format` (required).
 - **schema**: Returns database schema information. Parameters: `include_metadata` (optional,
   defaults to false).

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -146,8 +146,10 @@ pub trait Tiller {
     ) -> Res<usize>;
 
     /// Verify that the write was successful by re-fetching the sheet.
-    /// Returns the observed counts if verification passes.
-    async fn verify_write(&mut self, expected: &TillerData) -> Res<WriteCounts>;
+    ///
+    /// Returns the observed counts and the sheet's contents. The contents are the new baseline for
+    /// conflict detection: once a `sync up` succeeds, this is what both sides agree on.
+    async fn verify_write(&mut self, expected: &TillerData) -> Res<(WriteCounts, TillerData)>;
 }
 
 /// What a `sync up` actually left behind in the Google sheet, read back after writing.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -19,6 +19,7 @@ pub(super) use sheet_test_client::TestSheet;
 use std::env::VarError;
 
 use crate::error::{ErrorType, IntoResult, Res};
+use anyhow::Context;
 #[cfg(test)]
 pub(super) use sheet_test_client::{SheetCall, TestSheetState};
 
@@ -78,10 +79,20 @@ impl Mode {
 pub async fn sheet(config: Config, mode: Mode) -> Result<Box<dyn Sheet>> {
     let sheet_client: Box<dyn Sheet> = match mode {
         Mode::Google => {
+            // Credentials are only read here, when an operation actually needs the Google API.
+            // Nothing about starting the CLI or the MCP server touches them, and nothing outside
+            // `tiller auth` can start the interactive OAuth flow.
             let token_provider =
                 TokenProvider::load(config.client_secret_path(), config.token_path())
                     .await
-                    .pub_result(ErrorType::Config)?;
+                    .context(
+                        "Could not use the stored Google credentials. Someone needs to run \
+                         'tiller auth' in a terminal to re-authorize; it opens a browser and waits \
+                         for a person to approve, so it cannot be run unattended. If you are an \
+                         assistant working on the user's behalf, ask them to run it rather than \
+                         running it yourself.",
+                    )
+                    .pub_result(ErrorType::Auth)?;
             Box::new(
                 GoogleSheet::new(config.clone(), token_provider)
                     .await

--- a/src/api/oauth.rs
+++ b/src/api/oauth.rs
@@ -53,6 +53,8 @@ impl TokenProvider {
         P1: Into<PathBuf>,
         P2: Into<PathBuf>,
     {
+        require_a_terminal()?;
+
         let secret_path = secret.into();
         let token_path = token.into();
 
@@ -234,6 +236,33 @@ impl TokenProvider {
         self.token.save().await?;
         Ok(self.token())
     }
+}
+
+/// Refuses to start the interactive OAuth flow unless a person is at the keyboard.
+///
+/// The flow opens a browser and then blocks until the user authorizes in it. Started from anywhere
+/// else - a script, a CI job, or an AI agent's shell - it pops a browser window at the user without
+/// warning and then hangs until something times out. That is what an agent reaching for
+/// `tiller auth` after seeing an expired-token error looks like from the user's side, and it is
+/// what makes re-authorization appear to happen on its own.
+///
+/// There is no legitimate non-interactive use of this flow: it cannot complete without a human in a
+/// browser. `tiller auth --verify` is the scriptable command.
+///
+/// See <https://github.com/webern/tiller-sync/issues/34>.
+fn require_a_terminal() -> Res<()> {
+    use std::io::IsTerminal;
+
+    if std::io::stdin().is_terminal() {
+        return Ok(());
+    }
+
+    bail!(
+        "'tiller auth' has to be run by a person at a terminal. It opens a browser and waits for \
+         you to authorize there, so it cannot complete when started by a script, a background \
+         process, or an AI agent. Open a terminal and run 'tiller auth' yourself.\n\n\
+         To check existing credentials without any of that, use 'tiller auth --verify'."
+    )
 }
 
 /// Async HTTP client for OAuth2 requests using reqwest
@@ -437,5 +466,47 @@ async fn receive_oauth_callback(listener: TcpListener, expected_csrf: CsrfToken)
         Some(Ok(code)) => Ok(code),
         Some(Err(e)) => Err(e),
         None => bail!("Failed to receive authorization code"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Tests do not run with a terminal on stdin, which is the same situation an agent's shell or a
+    /// background process is in. The interactive flow must refuse rather than opening a browser at
+    /// the user and then blocking.
+    ///
+    /// See https://github.com/webern/tiller-sync/issues/34
+    #[tokio::test]
+    async fn test_interactive_auth_refuses_without_a_terminal() {
+        let result = TokenProvider::initialize("client_secret.json", "token.json").await;
+
+        let err = result
+            .expect_err("the interactive flow must not start without a terminal")
+            .to_string();
+        assert!(
+            err.contains("terminal"),
+            "the error should explain that a person has to run this, got: {err}"
+        );
+        assert!(
+            err.contains("--verify"),
+            "the error should point at the scriptable alternative, got: {err}"
+        );
+    }
+
+    /// The guard has to come before anything else, or a missing credentials file would be reported
+    /// instead and the real problem would be hidden.
+    #[tokio::test]
+    async fn test_terminal_check_precedes_reading_credentials() {
+        let result =
+            TokenProvider::initialize("/nonexistent/client_secret.json", "/nonexistent/token.json")
+                .await;
+
+        let err = result.expect_err("expected an error").to_string();
+        assert!(
+            err.contains("terminal"),
+            "the terminal check should run first, got: {err}"
+        );
     }
 }

--- a/src/api/tiller.rs
+++ b/src/api/tiller.rs
@@ -91,7 +91,7 @@ impl Tiller for TillerImpl {
         Ok(formulas_written)
     }
 
-    async fn verify_write(&mut self, expected: &TillerData) -> Res<WriteCounts> {
+    async fn verify_write(&mut self, expected: &TillerData) -> Res<(WriteCounts, TillerData)> {
         use anyhow::bail;
 
         // Re-fetch data from sheets to verify row counts
@@ -134,7 +134,7 @@ impl Tiller for TillerImpl {
             );
         }
 
-        Ok(counts)
+        Ok((counts, actual))
     }
 }
 

--- a/src/api/tiller.rs
+++ b/src/api/tiller.rs
@@ -2,7 +2,7 @@
 
 use crate::api::{Sheet, SheetRange, Tiller, WriteCounts, AUTO_CAT, CATEGORIES, TRANSACTIONS};
 use crate::error::Res;
-use crate::model::{AutoCats, Categories, TillerData, Transactions};
+use crate::model::{resolve_transaction_ids, AutoCats, Categories, TillerData, Transactions};
 use tracing::debug;
 
 /// Implements the `Tiller` trait for interacting with Google sheet data from a tiller sheet.
@@ -142,7 +142,14 @@ impl Tiller for TillerImpl {
 async fn fetch_transactions(client: &mut (dyn Sheet + Send)) -> Res<Transactions> {
     let values = client.get(TRANSACTIONS).await?;
     let formulas = client.get_formulas(TRANSACTIONS).await?;
-    Transactions::parse(values, formulas)
+    let mut transactions = Transactions::parse(values, formulas)?;
+
+    // Rows whose Transaction ID is blank or duplicated cannot be keyed on that value. Resolving
+    // here rather than in the sync commands means every read of the sheet is normalized the same
+    // way, so the conflict-detection snapshot and the verification read-back stay comparable.
+    resolve_transaction_ids(&mut transactions).log();
+
+    Ok(transactions)
 }
 
 /// Fetches category data from the Categories tab

--- a/src/args.rs
+++ b/src/args.rs
@@ -95,6 +95,27 @@ pub enum Command {
     ///
     /// Returns tables, columns, types, indexes, foreign keys, column descriptions, and row counts.
     Schema(SchemaArgs),
+    /// Show what has changed locally and in the Google Sheet since the last sync.
+    ///
+    /// Neither side is modified. Use this to see whether local edits still need uploading, or
+    /// whether the sheet has moved on, without running a sync in either direction.
+    Status(StatusArgs),
+}
+
+/// Args for the `tiller status` command.
+///
+/// Reports edits made to the local datastore since the last sync (which `sync down` would discard)
+/// and edits made to the Google Sheet since the last sync (which `sync up` would overwrite).
+#[derive(Debug, Clone, Parser, Serialize, Deserialize, JsonSchema, Default)]
+#[schemars(title = "StatusArgs")]
+pub struct StatusArgs {
+    /// Skip reading the Google Sheet and report local changes only.
+    ///
+    /// Reading the sheet needs network access and valid authentication. Use this when you only
+    /// want to know whether your local edits have been uploaded.
+    #[arg(long, default_value = "false")]
+    #[serde(default)]
+    pub local_only: bool,
 }
 
 /// Arguments common to all subcommands.
@@ -201,7 +222,11 @@ pub struct SyncArgs {
     /// The path to the Google OAuth token file, defaults to $TILLER_HOME/.secrets/token.json
     oauth_token: Option<PathBuf>,
 
-    /// Force sync up even if conflicts are detected or sync-down backup is missing
+    /// Proceed even when the sync would discard changes.
+    ///
+    /// For `sync down`, this discards local edits that have not been uploaded. For `sync up`, this
+    /// overwrites sheet changes made since the last download, and allows a sync up when no
+    /// sync-down backup exists.
     #[arg(long)]
     force: bool,
 

--- a/src/commands/insert.rs
+++ b/src/commands/insert.rs
@@ -61,6 +61,9 @@ pub async fn insert_transaction(
         no_name: String::new(),
         other_fields: utils::other_fields_map(args.other_fields),
         original_order: None, // Locally-added rows have no original order
+        // The generated ID is the ID we write to the sheet, so there is no separate sheet value to
+        // preserve.
+        original_transaction_id: None,
     };
 
     // Insert into database

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -8,6 +8,7 @@ mod init;
 mod insert;
 mod mcp;
 pub mod query;
+mod status;
 mod sync;
 mod update;
 
@@ -25,6 +26,7 @@ pub use init::init;
 pub use insert::{insert_autocat, insert_category, insert_transaction};
 pub use mcp::mcp;
 pub use query::{query, schema, ColumnInfo, ForeignKeyInfo, IndexInfo, Rows, Schema, TableInfo};
+pub use status::{status, SyncStatus};
 pub use sync::{sync_down, sync_up};
 pub use update::{update_autocats, update_categories, update_transactions};
 

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,0 +1,246 @@
+//! The `status` command: what has changed locally, and what has changed in the sheet.
+//!
+//! This exists so that "have my local edits been uploaded?" and "has the sheet changed since I last
+//! downloaded?" can be answered without running a sync. Answering the second question used to
+//! require a `sync down`, which is exactly the operation that discards unsynced local edits.
+//!
+//! See <https://github.com/webern/tiller-sync/issues/38>.
+
+use crate::api::{sheet, tiller, Mode, Tiller};
+use crate::backup::SYNC_DOWN;
+use crate::commands::sync::local_changes;
+use crate::commands::Out;
+use crate::error::{ErrorType, IntoResult};
+use crate::model::Changes;
+use crate::{Config, Result};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt::{Display, Formatter};
+
+/// Where the local datastore and the Google Sheet stand relative to the last sync.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct SyncStatus {
+    /// Whether a sync has ever run. Everything below is meaningless when this is false.
+    pub synced_before: bool,
+    /// Edits made to the local datastore since the last sync. `sync down` would discard these.
+    pub local: Changes,
+    /// Edits made to the Google Sheet since the last sync. `sync up` would overwrite these.
+    ///
+    /// Absent when the sheet was not read, which happens when `check_remote` is false.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote: Option<Changes>,
+}
+
+impl Display for SyncStatus {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string_pretty(self) {
+            Ok(s) => write!(f, "{s}"),
+            Err(_) => write!(f, "{self:?}"),
+        }
+    }
+}
+
+/// Reports what has changed locally and, optionally, in the Google Sheet.
+///
+/// Reading the sheet costs an API call and requires valid authentication, so `check_remote` makes
+/// it opt-out: the local half of the answer is always available offline.
+pub async fn status(config: Config, mode: Mode, check_remote: bool) -> Result<Out<SyncStatus>> {
+    let Some(local) = local_changes(&config).await? else {
+        return Ok(Out::new(
+            "No sync has run yet, so there is nothing to compare against. Run 'tiller sync down' \
+             to download the sheet.",
+            SyncStatus {
+                synced_before: false,
+                local: Changes::default(),
+                remote: None,
+            },
+        ));
+    };
+
+    let remote = if check_remote {
+        Some(remote_changes(&config, mode).await?)
+    } else {
+        None
+    };
+
+    let message = describe(&local, remote.as_ref());
+    Ok(Out::new(
+        message,
+        SyncStatus {
+            synced_before: true,
+            local,
+            remote,
+        },
+    ))
+}
+
+/// Compares the Google Sheet against the last known state of it.
+async fn remote_changes(config: &Config, mode: Mode) -> Result<Changes> {
+    let last_synced = config
+        .backup()
+        .load_latest_json(SYNC_DOWN)
+        .await
+        .pub_result(ErrorType::Internal)?
+        .ok_or_else(|| anyhow::anyhow!("No sync-down backup found"))
+        .pub_result(ErrorType::Internal)?;
+
+    let sheet_client = sheet(config.clone(), mode).await?;
+    let mut tiller_client = tiller(sheet_client).await.pub_result(ErrorType::Internal)?;
+    let current = tiller_client.get_data().await.pub_result(ErrorType::Sync)?;
+
+    Ok(Changes::between(&last_synced, &current))
+}
+
+/// Turns the comparison into a sentence that says what to do next.
+fn describe(local: &Changes, remote: Option<&Changes>) -> String {
+    let local_dirty = !local.is_empty();
+    let remote_dirty = remote.is_some_and(|r| !r.is_empty());
+
+    match (local_dirty, remote_dirty) {
+        (false, false) if remote.is_some() => {
+            "Local datastore and sheet are both in step with the last sync.".to_string()
+        }
+        (false, false) => "No local changes since the last sync.".to_string(),
+        (true, false) => format!(
+            "Local changes not yet in the sheet: {local}. Run 'tiller sync up' to upload them."
+        ),
+        (false, true) => format!(
+            "The sheet has changed since the last sync: {}. Run 'tiller sync down' to pull them in.",
+            remote.unwrap_or(&Changes::default())
+        ),
+        (true, true) => format!(
+            "Both sides have changed. Local: {local}. Sheet: {}. Neither sync direction can \
+             preserve both, so reconcile them before syncing, or choose a side with --force.",
+            remote.unwrap_or(&Changes::default())
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::args::DeleteTransactionsArgs;
+    use crate::commands::{sync_down, sync_up, FormulasMode};
+    use crate::model::TransactionUpdates;
+    use crate::test::TestEnv;
+
+    #[tokio::test]
+    async fn test_status_before_any_sync() {
+        let env = TestEnv::new().await;
+        let out = status(env.config(), Mode::Testing, false).await.unwrap();
+
+        assert!(!out.structure().unwrap().synced_before);
+        assert!(out.message().contains("No sync has run yet"));
+    }
+
+    #[tokio::test]
+    async fn test_status_is_clean_right_after_sync_down() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert!(structure.local.is_empty(), "local: {}", structure.local);
+        assert!(
+            structure.remote.unwrap().is_empty(),
+            "the sheet has not been touched"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_status_reports_local_edits() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, false).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert_eq!(structure.local.transactions.modified, 1);
+        assert!(
+            out.message().contains("sync up"),
+            "the message should say what to do, got: {}",
+            out.message()
+        );
+    }
+
+    /// The remote half is the point of the command: checking for sheet changes used to require a
+    /// `sync down`, which is the operation that discards local edits.
+    #[tokio::test]
+    async fn test_status_reports_remote_edits_without_downloading() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        // Edit the sheet behind the tool's back.
+        let mut state = env.get_state();
+        state.data.get_mut("Transactions").unwrap()[1][2].push_str(" (edited)");
+        env.set_state(state);
+
+        let out = status(config.clone(), Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert_eq!(structure.remote.unwrap().transactions.modified, 1);
+        assert!(structure.local.is_empty(), "the datastore was not touched");
+
+        // And the datastore was genuinely left alone.
+        let after = config.db().get_tiller_data().await.unwrap();
+        assert!(!after.transactions.data()[0]
+            .description
+            .contains("(edited)"));
+    }
+
+    /// After uploading, both sides agree again. Without a refreshed baseline, `status` and
+    /// `sync down` would keep reporting the just-uploaded edits as unsynced forever.
+    #[tokio::test]
+    async fn test_status_is_clean_after_sync_up() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let args = DeleteTransactionsArgs::new(vec![id]).unwrap();
+        crate::commands::delete_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        let out = status(config, Mode::Testing, true).await.unwrap();
+        let structure = out.structure().unwrap();
+
+        assert!(
+            structure.local.is_empty(),
+            "after uploading, the local datastore is in step: {}",
+            structure.local
+        );
+        assert!(
+            structure.remote.unwrap().is_empty(),
+            "after uploading, the sheet is in step"
+        );
+    }
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -2,13 +2,37 @@ use super::{FormulasMode, Out};
 use crate::api::{sheet, tiller, Mode, Tiller};
 use crate::backup::{SYNC_DOWN, SYNC_UP_PRE};
 use crate::error::{ErrorType, IntoResult};
+use crate::model::Changes;
 use crate::{Config, Result};
 use anyhow::anyhow;
 use tracing::{debug, info, warn};
 
 /// Gets data from the tiller Google sheet and persists it to the local datastore. Returns an info
 /// message that can be printed for the user.
-pub async fn sync_down(config: Config, mode: Mode) -> Result<Out<()>> {
+///
+/// `sync down` overwrites the local datastore: transactions are upserted from the sheet, and
+/// categories and AutoCat are replaced outright. Any local edit that has not been uploaded is lost.
+/// Unless `force` is set, the command therefore refuses to run when the datastore has been edited
+/// since it was last in step with the sheet.
+pub async fn sync_down(config: Config, mode: Mode, force: bool) -> Result<Out<()>> {
+    // Refuse to overwrite local edits that have never been uploaded.
+    let local_changes = local_changes(&config).await?;
+    match local_changes {
+        Some(changes) if !changes.is_empty() => {
+            if !force {
+                return Err(anyhow!(
+                    "The local datastore has changes that are not in the sheet: {changes}. \
+                     Running 'sync down' now would discard them. Run 'tiller sync up' first to \
+                     upload them, or use --force to discard them and overwrite with the sheet's \
+                     contents. Use 'tiller status' to see the local and remote state."
+                ))
+                .pub_result(ErrorType::Sync);
+            }
+            warn!("Discarding local changes and overwriting from the sheet (--force): {changes}");
+        }
+        _ => {}
+    }
+
     // Backup SQLite database before modifying
     let sqlite_backup = config
         .backup()
@@ -43,6 +67,29 @@ pub async fn sync_down(config: Config, mode: Mode) -> Result<Out<()>> {
         tiller_data.categories.data().len(),
         tiller_data.auto_cats.data().len()
     )))
+}
+
+/// Compares the local datastore against the last known state of the sheet.
+///
+/// Returns `None` when there is no snapshot to compare against, which means no sync has ever run
+/// and there is nothing local to protect.
+pub(crate) async fn local_changes(config: &Config) -> Result<Option<Changes>> {
+    let Some(last_synced) = config
+        .backup()
+        .load_latest_json(SYNC_DOWN)
+        .await
+        .pub_result(ErrorType::Internal)?
+    else {
+        return Ok(None);
+    };
+
+    let local = config
+        .db()
+        .get_tiller_data()
+        .await
+        .pub_result(ErrorType::Database)?;
+
+    Ok(Some(Changes::between(&last_synced, &local)))
 }
 
 /// Sends data from the local datastore to the Google sheet, returns a message that can be printed
@@ -100,15 +147,18 @@ pub async fn sync_up(
         Some(backup_data) => {
             // Compare current sheet with backup
             if current_sheet != backup_data {
+                let changes = Changes::between(&backup_data, &current_sheet);
                 if !force {
                     return Err(anyhow!(
-                        "Sheet has been modified since last sync down. \
-                         Run 'tiller sync down' first to merge changes, \
-                         or use --force to overwrite"
+                        "The sheet has been modified since the last sync down: {changes}. \
+                         Merge those changes first, or use --force to overwrite them with the \
+                         local datastore. Use 'tiller status' to see what differs."
                     ))
                     .pub_result(ErrorType::Sync);
                 }
-                warn!("Sheet differs from last sync-down, proceeding anyway (--force)");
+                warn!(
+                    "Overwriting sheet changes made since the last sync down (--force): {changes}"
+                );
             }
         }
     }
@@ -179,10 +229,21 @@ pub async fn sync_up(
         .pub_result(ErrorType::Sync)?;
 
     // Verification - re-fetch and compare against what we meant to write
-    let counts = tiller_client
+    let (counts, sheet_after_write) = tiller_client
         .verify_write(&db_data)
         .await
         .pub_result(ErrorType::Sync)?;
+
+    // Record the new baseline. Both sides now agree on this, so it is what the next `sync down`
+    // measures local edits against and what the next `sync up` measures remote edits against.
+    // Without it, every command after a successful upload would report the edits just uploaded as
+    // unsynced changes.
+    let baseline = config
+        .backup()
+        .save_json(SYNC_DOWN, &sheet_after_write)
+        .await
+        .pub_result(ErrorType::Internal)?;
+    debug!("Saved post-upload baseline to {}", baseline.display());
 
     // Preserve formulas if requested.
     let formula_summary = if preserve_formulas {
@@ -226,7 +287,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Verify SQLite backup was created
         let backup_files: Vec<_> = std::fs::read_dir(config.backups())
@@ -313,7 +376,9 @@ mod tests {
         let config = env.config();
 
         // First run sync_down to populate the database (precondition for sync_up)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Run sync_up - should create sync-up-pre backup
         sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
@@ -342,7 +407,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete all sync-down.*.json backup files
         for entry in std::fs::read_dir(config.backups()).unwrap() {
@@ -374,7 +441,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete all sync-down.*.json backup files
         for entry in std::fs::read_dir(config.backups()).unwrap() {
@@ -401,7 +470,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database and create backup
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Update the remote sheet with some change (row 1 is first data row, row 0 is header)
         let mut state = env.get_state();
@@ -439,7 +510,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database and create backup
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Update the remote sheet with some change (row 1 is first data row, row 0 is header)
         let mut state = env.get_state();
@@ -470,7 +543,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         // (e.g., if we have rows with original_order 0, 1, 2, deleting row 1 creates gap 0, 2)
@@ -502,7 +577,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         let db = config.db();
@@ -528,7 +605,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete a transaction from the database to create a gap in original_order
         let db = config.db();
@@ -554,7 +633,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Count existing SQLite backups (sync_down creates one)
         let backup_count_before: usize = std::fs::read_dir(config.backups())
@@ -597,7 +678,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -628,7 +711,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -697,7 +782,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Clear call history to isolate sync_up calls
         let test_sheet = TestSheet::new(config.spreadsheet_id());
@@ -738,7 +825,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database (test data includes formulas)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Verify that formulas actually exist in the database
         let db_data = config.db().get_tiller_data().await.unwrap();
@@ -784,6 +873,118 @@ mod tests {
         env.set_state(state);
     }
 
+    /// The README and the MCP instructions used to say "always run sync_down first". Taken at face
+    /// value after local edits, that silently reverts every recategorization and deletes every
+    /// locally-added AutoCat rule. `sync down` now refuses rather than destroying the work.
+    ///
+    /// See https://github.com/webern/tiller-sync/issues/38
+    #[tokio::test]
+    async fn test_sync_down_refuses_to_discard_local_changes() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        // Recategorize a transaction, exactly the edit the reporter nearly lost.
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id.clone()], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        let result = sync_down(config.clone(), Mode::Testing, false).await;
+
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("1 transaction") && err.contains("sync up"),
+            "the error should name what would be lost and how to keep it, got: {err}"
+        );
+
+        // And the edit is still there.
+        let after = config.db()._get_transaction(&id).await.unwrap().unwrap();
+        assert_eq!(after.category, "Restaurants");
+    }
+
+    /// Discarding local work has to remain possible, just deliberate.
+    #[tokio::test]
+    async fn test_sync_down_discards_local_changes_with_force() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let original = data.transactions.data()[0].category.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id.clone()], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, true)
+            .await
+            .expect("--force should allow the overwrite");
+
+        let after = config.db()._get_transaction(&id).await.unwrap().unwrap();
+        assert_eq!(after.category, original, "the sheet's value should win");
+    }
+
+    /// A clean datastore must sync down without ceremony, or the guard would be worse than the
+    /// problem it solves.
+    #[tokio::test]
+    async fn test_sync_down_proceeds_when_nothing_changed_locally() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .expect("a second sync down with no local edits should just work");
+    }
+
+    /// The normal workflow is sync down, edit, sync up, sync down. That last step must not be
+    /// blocked by the edits that were just uploaded.
+    #[tokio::test]
+    async fn test_sync_down_after_sync_up_is_not_blocked() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let id = data.transactions.data()[0].transaction_id.clone();
+        let updates = crate::model::TransactionUpdates {
+            category: Some("Restaurants".to_string()),
+            ..Default::default()
+        };
+        let args = crate::args::UpdateTransactionsArgs::new(vec![id], updates).unwrap();
+        crate::commands::update_transactions(config.clone(), args)
+            .await
+            .unwrap();
+
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .expect("after uploading, the datastore is in step and sync down should work");
+    }
+
     /// `transactions.transaction_id` is a primary key, and real sheets violate uniqueness: some
     /// feeds supply no ID at all, and malformed split markers repeat `split:[1]` across rows.
     /// `sync down` used to abort on the first such row with a bare UNIQUE constraint error.
@@ -805,7 +1006,7 @@ mod tests {
             ],
         );
 
-        let out = sync_down(config.clone(), Mode::Testing)
+        let out = sync_down(config.clone(), Mode::Testing, false)
             .await
             .expect("sync down must not abort on unusable Transaction IDs");
         assert!(out.message().contains("20 transactions"), "no row was lost");
@@ -843,7 +1044,9 @@ mod tests {
         let config = env.config();
 
         set_transaction_ids(&env, &[(0, ""), (1, "")]);
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let first: Vec<String> = config
             .db()
@@ -856,7 +1059,9 @@ mod tests {
             .map(|t| t.transaction_id.clone())
             .collect();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let second: Vec<String> = config
             .db()
@@ -882,7 +1087,9 @@ mod tests {
         let config = env.config();
 
         set_transaction_ids(&env, &[(0, ""), (1, "split:[1]"), (2, "split:[1]")]);
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let test_sheet = TestSheet::new(config.spreadsheet_id());
         test_sheet.clear_history();
@@ -925,7 +1132,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let db_data = config.db().get_tiller_data().await.unwrap();
         let expected_formulas = db_data.transactions.formulas().clone();
@@ -985,7 +1194,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         let test_sheet = TestSheet::new(config.spreadsheet_id());
         test_sheet.clear_history();
@@ -1022,7 +1233,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
         let expected = config
             .db()
             .get_tiller_data()
@@ -1050,7 +1263,9 @@ mod tests {
         let env = TestEnv::new().await;
         let config = env.config();
 
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Delete the last transaction, so the formula bound to the final row has no row left.
         let db = config.db();
@@ -1079,7 +1294,9 @@ mod tests {
         let config = env.config();
 
         // Run sync_down to populate the database (this also seeds the TestSheet)
-        sync_down(config.clone(), Mode::Testing).await.unwrap();
+        sync_down(config.clone(), Mode::Testing, false)
+            .await
+            .unwrap();
 
         // Capture original sheet state after sync_down (seed data is now loaded)
         let test_sheet = TestSheet::new(config.spreadsheet_id());

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -763,6 +763,160 @@ mod tests {
         );
     }
 
+    /// Finds the 0-based index of a column in the test sheet's Transactions tab.
+    fn column_index(env: &TestEnv, header: &str) -> usize {
+        env.seed_sheet();
+        env.get_state().data[TRANSACTIONS][0]
+            .iter()
+            .position(|h| h == header)
+            .unwrap_or_else(|| panic!("the test sheet should have a {header} column"))
+    }
+
+    /// Rewrites the Transaction ID of the given data rows (0-based, excluding the header).
+    fn set_transaction_ids(env: &TestEnv, ids: &[(usize, &str)]) {
+        env.seed_sheet();
+        let col = column_index(env, "Transaction ID");
+        let mut state = env.get_state();
+        let rows = state.data.get_mut(TRANSACTIONS).unwrap();
+        for (data_row, id) in ids {
+            rows[data_row + 1][col] = id.to_string();
+        }
+        env.set_state(state);
+    }
+
+    /// `transactions.transaction_id` is a primary key, and real sheets violate uniqueness: some
+    /// feeds supply no ID at all, and malformed split markers repeat `split:[1]` across rows.
+    /// `sync down` used to abort on the first such row with a bare UNIQUE constraint error.
+    ///
+    /// See https://github.com/webern/tiller-sync/issues/37
+    #[tokio::test]
+    async fn test_sync_down_handles_blank_and_duplicate_ids() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        set_transaction_ids(
+            &env,
+            &[
+                (0, ""),
+                (1, ""),
+                (2, "split:[1]"),
+                (3, "split:[1]"),
+                (4, "split:[2]"),
+            ],
+        );
+
+        let out = sync_down(config.clone(), Mode::Testing)
+            .await
+            .expect("sync down must not abort on unusable Transaction IDs");
+        assert!(out.message().contains("20 transactions"), "no row was lost");
+
+        let data = config.db().get_tiller_data().await.unwrap();
+        let resolved: Vec<_> = data
+            .transactions
+            .data()
+            .iter()
+            .filter(|t| t.original_transaction_id.is_some())
+            .collect();
+
+        // Two blanks and the two rows sharing `split:[1]`. The lone `split:[2]` is unique, so it
+        // is left alone.
+        assert_eq!(resolved.len(), 4);
+        for transaction in &resolved {
+            assert!(
+                transaction.transaction_id.starts_with("user-"),
+                "an unusable ID should be replaced by a surrogate, got: {}",
+                transaction.transaction_id
+            );
+        }
+        assert!(data
+            .transactions
+            .data()
+            .iter()
+            .any(|t| t.transaction_id == "split:[2]" && t.original_transaction_id.is_none()));
+    }
+
+    /// A second `sync down` must recognize the same rows rather than deleting and re-adding them,
+    /// which would discard any local edits made to them.
+    #[tokio::test]
+    async fn test_repeated_sync_down_keeps_the_same_surrogates() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        set_transaction_ids(&env, &[(0, ""), (1, "")]);
+        sync_down(config.clone(), Mode::Testing).await.unwrap();
+
+        let first: Vec<String> = config
+            .db()
+            .get_tiller_data()
+            .await
+            .unwrap()
+            .transactions
+            .data()
+            .iter()
+            .map(|t| t.transaction_id.clone())
+            .collect();
+
+        sync_down(config.clone(), Mode::Testing).await.unwrap();
+
+        let second: Vec<String> = config
+            .db()
+            .get_tiller_data()
+            .await
+            .unwrap()
+            .transactions
+            .data()
+            .iter()
+            .map(|t| t.transaction_id.clone())
+            .collect();
+
+        assert_eq!(
+            first, second,
+            "surrogate IDs must be stable, or every sync would re-key the row and lose local edits"
+        );
+    }
+
+    /// The surrogate is a local convenience. The sheet must get its own values back.
+    #[tokio::test]
+    async fn test_sync_up_writes_the_original_ids_back() {
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        set_transaction_ids(&env, &[(0, ""), (1, "split:[1]"), (2, "split:[1]")]);
+        sync_down(config.clone(), Mode::Testing).await.unwrap();
+
+        let test_sheet = TestSheet::new(config.spreadsheet_id());
+        test_sheet.clear_history();
+
+        sync_up(config.clone(), Mode::Testing, false, FormulasMode::Ignore)
+            .await
+            .unwrap();
+
+        let history = test_sheet.call_history();
+        let SheetCall::WriteRanges { ranges } = history
+            .iter()
+            .find(|c| matches!(c, SheetCall::WriteRanges { .. }))
+            .expect("sync_up should write data")
+        else {
+            unreachable!("filtered on WriteRanges")
+        };
+        let (_, written) = ranges
+            .iter()
+            .find(|(r, _)| r.contains(TRANSACTIONS))
+            .expect("sync_up should write the Transactions tab");
+
+        let col = column_index(&env, "Transaction ID");
+        assert_eq!(written[1][col], "", "a blank ID must stay blank");
+        assert_eq!(written[2][col], "split:[1]");
+        assert_eq!(written[3][col], "split:[1]");
+        for row in written.iter().skip(1) {
+            assert!(
+                !row[col].starts_with("user-"),
+                "a surrogate ID must never be written into the sheet, found: {}",
+                row[col]
+            );
+        }
+    }
+
     /// `--formulas preserve` now actually preserves formulas.
     ///
     /// See https://github.com/webern/tiller-sync/issues/35

--- a/src/db/migrations/migration_03_down.sql
+++ b/src/db/migrations/migration_03_down.sql
@@ -1,0 +1,8 @@
+-- Migration 03 (down): Remove the original_transaction_id column
+--
+-- Rows that were given a surrogate ID keep it, but the sheet's own value is lost, so a `sync up`
+-- after this downgrade would write surrogate IDs into the Transactions tab. Run `sync down` again
+-- after downgrading to restore the sheet's values.
+
+ALTER TABLE transactions
+    DROP COLUMN original_transaction_id;

--- a/src/db/migrations/migration_03_up.sql
+++ b/src/db/migrations/migration_03_up.sql
@@ -1,0 +1,11 @@
+-- Migration 03: Record the sheet's own Transaction ID when it cannot serve as a primary key
+--
+-- Real Tiller sheets contain rows whose Transaction ID is blank (some feeds, notably Apple Card,
+-- supply no IDs) or duplicated (malformed split markers such as `split:[1]`). Those values cannot
+-- be a primary key, so `sync down` assigns a surrogate `user-` ID to such rows.
+--
+-- `original_transaction_id` holds the sheet's value verbatim so `sync up` can write it back
+-- unchanged. It is NULL for the ordinary case, where `transaction_id` is the sheet's own value.
+
+ALTER TABLE transactions
+    ADD COLUMN original_transaction_id TEXT;

--- a/src/db/migrations/mod.rs
+++ b/src/db/migrations/mod.rs
@@ -54,6 +54,11 @@ const MIGRATIONS: &[Migration] = &[
         up: MigrationAction::Rust(migration_02_up),
         down: MigrationAction::Rust(migration_02_down),
     },
+    Migration {
+        version: 3,
+        up: MigrationAction::Sql(include_str!("migration_03_up.sql")),
+        down: MigrationAction::Sql(include_str!("migration_03_down.sql")),
+    },
 ];
 
 // ============================================================================
@@ -490,18 +495,19 @@ mod tests {
 
     #[test]
     fn testvalidate_migrations_succeeds_for_valid_range() {
-        // Migrations 1 and 2 exist, so this should succeed
-        assert!(validate_migrations(0, 1).is_ok());
-        assert!(validate_migrations(1, 0).is_ok());
-        assert!(validate_migrations(0, 2).is_ok());
-        assert!(validate_migrations(2, 0).is_ok());
+        // Every migration up to CURRENT_VERSION exists, in both directions.
+        for version in 1..=crate::db::CURRENT_VERSION {
+            assert!(validate_migrations(0, version).is_ok());
+            assert!(validate_migrations(version, 0).is_ok());
+        }
     }
 
     #[test]
     fn testvalidate_migrations_fails_for_missing_migration() {
-        // Migration 3 doesn't exist
-        assert!(validate_migrations(0, 3).is_err());
-        assert!(validate_migrations(2, 4).is_err());
+        // There is no migration beyond CURRENT_VERSION.
+        let beyond = crate::db::CURRENT_VERSION + 1;
+        assert!(validate_migrations(0, beyond).is_err());
+        assert!(validate_migrations(beyond, beyond + 1).is_err());
     }
 
     #[tokio::test]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,7 +24,7 @@ use std::str::FromStr;
 
 /// The target schema version for the database. This equals the highest migration number available.
 /// When `migration_05_up.sql` is the highest numbered migration, this should be `5`.
-pub(crate) const CURRENT_VERSION: i32 = 2;
+pub(crate) const CURRENT_VERSION: i32 = 3;
 
 /// Represents a row in the database in a table for which the primary key is not known in
 /// `TillerData`. Namely, rows from the `categories` and `autocats` tables.
@@ -290,7 +290,8 @@ impl Db {
                 transaction_id, date, description, amount, account, account_number,
                 institution, month, week, full_description, account_id, check_number,
                 date_added, merchant_name, category_hint, category, note, tags,
-                categorized_date, statement, metadata, other_fields, original_order
+                categorized_date, statement, metadata, other_fields, original_order,
+                original_transaction_id
             FROM transactions ORDER BY original_order ASC NULLS LAST, transaction_id ASC"#,
         )
         .fetch_all(&self.pool)
@@ -343,7 +344,10 @@ impl Db {
                 metadata: r.get::<Option<String>, _>("metadata").unwrap_or_default(),
                 other_fields,
                 original_order: r.get::<Option<u64>, _>("original_order"),
-                ..Default::default()
+                original_transaction_id: r.get::<Option<String>, _>("original_transaction_id"),
+                // `no_name` (the unnamed column A that some sheets have) has no column in the
+                // `transactions` table, so there is nothing to read it from.
+                no_name: String::new(),
             });
         }
 
@@ -555,7 +559,8 @@ impl Db {
                 institution = ?, month = ?, week = ?, full_description = ?, account_id = ?,
                 check_number = ?, date_added = ?, merchant_name = ?, category_hint = ?,
                 category = ?, note = ?, tags = ?, categorized_date = ?, statement = ?,
-                metadata = ?, other_fields = ?, original_order = ?
+                metadata = ?, other_fields = ?, original_order = ?,
+                original_transaction_id = ?
             WHERE transaction_id = ?"#,
         )
         .bind(&txn.date)
@@ -580,6 +585,7 @@ impl Db {
         .bind(&txn.metadata)
         .bind(&other_fields_json)
         .bind(txn.original_order.map(|i| i as i64))
+        .bind(&txn.original_transaction_id)
         .bind(&txn.transaction_id)
         .execute(executor)
         .await
@@ -606,7 +612,8 @@ impl Db {
                 transaction_id, date, description, amount, account, account_number,
                 institution, month, week, full_description, account_id, check_number,
                 date_added, merchant_name, category_hint, category, note, tags,
-                categorized_date, statement, metadata, other_fields, original_order
+                categorized_date, statement, metadata, other_fields, original_order,
+                original_transaction_id
             FROM transactions WHERE transaction_id = ?"#,
         )
         .bind(id)
@@ -664,6 +671,7 @@ impl Db {
                     metadata: r.get::<Option<String>, _>("metadata").unwrap_or_default(),
                     other_fields,
                     original_order: r.get::<Option<u64>, _>("original_order"),
+                    original_transaction_id: r.get::<Option<String>, _>("original_transaction_id"),
                     // `no_name` (the unnamed column A that some sheets have) has no column in the
                     // `transactions` table, so there is nothing to read it from.
                     no_name: String::new(),
@@ -1177,8 +1185,9 @@ impl Db {
                 transaction_id, date, description, amount, account, account_number,
                 institution, month, week, full_description, account_id, check_number,
                 date_added, merchant_name, category_hint, category, note, tags,
-                categorized_date, statement, metadata, other_fields, original_order
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
+                categorized_date, statement, metadata, other_fields, original_order,
+                original_transaction_id
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"#,
         )
         .bind(&txn.transaction_id)
         .bind(&txn.date)
@@ -1203,6 +1212,7 @@ impl Db {
         .bind(&txn.metadata)
         .bind(&other_fields_json)
         .bind(txn.original_order.map(|i| i as i64))
+        .bind(&txn.original_transaction_id)
         .execute(ex)
         .await
         .context("Failed to insert transaction")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,9 @@ pub async fn main_inner(args: Args) -> Result<()> {
                         .await?
                         .print()
                 }
-                UpDown::Down => commands::sync_down(config, mode).await?.print(),
+                UpDown::Down => commands::sync_down(config, mode, sync_args.force())
+                    .await?
+                    .print(),
             }
         }
 
@@ -133,6 +135,13 @@ pub async fn main_inner(args: Args) -> Result<()> {
         Command::Schema(schema_args) => {
             let config = Config::load(home).await?;
             commands::schema(config, schema_args.clone())
+                .await?
+                .print_data()?
+        }
+
+        Command::Status(status_args) => {
+            let config = Config::load(home).await?;
+            commands::status(config, mode, !status_args.local_only)
                 .await?
                 .print_data()?
         }

--- a/src/mcp/docs/INSTRUCTIONS.md
+++ b/src/mcp/docs/INSTRUCTIONS.md
@@ -34,13 +34,26 @@ Three types of data are synchronized:
 ## Recommended Workflow
 
 ```
-1. sync_down          <- Download latest data from Google Sheet
-2. [analyze/edit]     <- Work with local SQLite database
-3. sync_up            <- Upload changes back to Google Sheet
+1. sync_status        <- See where things stand
+2. sync_down          <- Download latest data from Google Sheet
+3. [analyze/edit]     <- Work with local SQLite database
+4. sync_up            <- Upload changes back to Google Sheet
 ```
 
-Always run `sync_down` before making local edits to ensure you have the latest data and to
-establish a baseline for conflict detection.
+Run `sync_down` at the **start** of a round of edits, to get fresh data and establish a baseline for
+conflict detection.
+
+**Never run `sync_down` between editing and `sync_up`.** It is not a refresh: transactions are
+upserted from the sheet, overwriting local field values, and Categories and AutoCat are deleted
+outright and replaced. Every recategorization and every locally-added AutoCat rule that has not been
+uploaded is gone.
+
+`sync_down` will refuse to run when the local database has unsynced changes, and will name what
+would be lost. Do not reach for `force=true` to get past that message: it means exactly what it
+says. Run `sync_up` first.
+
+To find out whether the sheet has changed without downloading it, use `sync_status`, which reads the
+sheet but writes nothing.
 
 ## Tool Reference
 
@@ -68,6 +81,22 @@ Downloads data from the Google Sheet to the local SQLite database.
   original_transaction_id IS NOT NULL`
 
 **Caution:** This overwrites local changes. The SQLite backup enables manual recovery if needed.
+
+### `sync_status`
+
+Reports what has changed on each side since the last sync. Modifies nothing.
+
+**Parameters:**
+
+| Parameter    | Type    | Default | Description                                              |
+|--------------|---------|---------|----------------------------------------------------------|
+| `local_only` | boolean | `false` | Report local changes only; do not read the Google Sheet  |
+
+**Returns:** `local` and `remote` counts of rows added, modified, and deleted per tab. `local` is
+what `sync_down` would discard; `remote` is what `sync_up` would overwrite.
+
+Comparison uses each row's sheet representation, so it reports what a sync can actually carry. A
+field that has no column in your sheet cannot be uploaded and is not counted.
 
 ### `sync_up`
 
@@ -143,6 +172,7 @@ Common errors and resolutions:
 
 | Error                              | Cause                               | Resolution                            |
 |------------------------------------|-------------------------------------|---------------------------------------|
+| "The local datastore has changes"  | Unsynced local edits                | Run `sync_up` first, or `force=true`  |
 | "Database has no transactions"     | Empty local database                | Run `sync_down` first                 |
 | "No sync-down backup found"        | Never ran `sync_down`               | Run `sync_down` or use `force=true`   |
 | "Sheet has been modified since..." | Remote changes detected             | Run `sync_down` or use `force=true`   |
@@ -266,7 +296,9 @@ Retrieves database schema information to help understand the data structure.
 
 ## Best Practices
 
-1. **Always sync down first** - Establishes baseline for conflict detection and ensures fresh data
+1. **Sync down at the start of a session, not in the middle of one** - It gives you fresh data and a
+   baseline for conflict detection, but it overwrites unsynced local edits. Use `sync_status` to
+   check the sheet mid-session instead
 2. **Use `formulas=ignore` when uncertain** - Safest option if you don't need formula preservation
 3. **Avoid `force=true` casually** - It bypasses safety checks; use only when intentional
 4. **Use `schema` before complex queries** - Understand the data structure before writing SQL

--- a/src/mcp/docs/INSTRUCTIONS.md
+++ b/src/mcp/docs/INSTRUCTIONS.md
@@ -4,6 +4,9 @@ This MCP server synchronizes financial data between a Tiller Google Sheet and a 
 database. The local database serves as a workspace for analysis and manipulation before syncing
 changes back to the sheet.
 
+Reading this is optional. Every tool documents its own parameters and behavior in its description;
+this guide covers the wider picture that spans several tools.
+
 ## Prerequisites
 
 The user must have already completed CLI setup before using these tools:

--- a/src/mcp/docs/INSTRUCTIONS.md
+++ b/src/mcp/docs/INSTRUCTIONS.md
@@ -58,6 +58,11 @@ Downloads data from the Google Sheet to the local SQLite database.
 - Categories and AutoCat are fully replaced
 - Cell formulas are captured and stored for optional preservation during `sync_up`
 - Each row's `original_order` is recorded for formula position tracking
+- Rows whose `Transaction ID` is blank or duplicated in the sheet are given a surrogate `user-` ID
+  so they can be keyed locally. Their sheet value is kept in `original_transaction_id` and written
+  back unchanged on `sync_up`. To find them:
+  `SELECT original_transaction_id, transaction_id, date, description FROM transactions WHERE
+  original_transaction_id IS NOT NULL`
 
 **Caution:** This overwrites local changes. The SQLite backup enables manual recovery if needed.
 
@@ -246,6 +251,7 @@ Retrieves database schema information to help understand the data structure.
 | Column           | Type    | Description                                          |
 |------------------|---------|------------------------------------------------------|
 | `transaction_id` | TEXT    | Unique ID (Tiller-assigned or `user-` prefixed)      |
+| `original_transaction_id` | TEXT | The sheet's own ID when it was blank or duplicated; NULL otherwise |
 | `date`           | TEXT    | Transaction date (YYYY-MM-DD)                        |
 | `description`    | TEXT    | Cleaned merchant description                         |
 | `amount`         | TEXT    | Transaction amount (negative = expense)              |

--- a/src/mcp/docs/INTRO.md
+++ b/src/mcp/docs/INTRO.md
@@ -1,11 +1,25 @@
-# MCP Service Description
+# Tiller Sync
 
-[Tiller](https://tiller.com/) is a third-party service that aggregates and categorizes financial
-transactions into a Google sheet.
+[Tiller](https://tiller.com/) aggregates and categorizes financial transactions into a Google Sheet.
+This server syncs that sheet with a local SQLite database, where the data can be queried and edited,
+and syncs changes back.
 
-This MCP server offers the user the ability to download these financial transactions into a local
-SQLite database for further analysis and manipulation. The local datastore may also be written back
-to the user's tiller Google sheet.
+Use it for anything about the user's spending, budget, transactions, categories, or AutoCat rules.
 
-You, the AI agent, **MUST** read the full instructions by calling __initialize_service__ before
-calling any other tools.
+## Tools
+
+- `sync_down` — download the sheet into the local database.
+- `sync_up` — upload the local database to the sheet.
+- `query` / `schema` — read-only SQL against the local database, and its structure.
+- `insert_*`, `update_*`, `delete_*` — edit transactions, categories, and AutoCat rules locally.
+- `instructions` — the in-depth guide, if you want more than each tool's own documentation.
+
+## What to know before you start
+
+- **Local edits are not automatically synced.** Nothing reaches the Google Sheet until `sync_up`.
+- **`sync_down` overwrites local changes.** Run it before *starting* a round of edits, not between
+  editing and `sync_up`. See `instructions` for how to check for remote changes without it.
+- **`force` and `formulas` on `sync_up` exist to prevent data loss.** Read `sync_up`'s own
+  documentation before setting either.
+- Setup (`tiller init` and `tiller auth`) happens on the command line, not through this server. If
+  the tools report an authentication error, ask the user to run `tiller auth` in a terminal.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -3,28 +3,15 @@
 //! This module provides an MCP server that exposes tiller functionality as tools
 //! for AI agent integration. The server communicates via JSON-RPC over stdio.
 
-/// Checks if the server has been initialized and returns an error if not.
-macro_rules! require_init {
-    ($self:expr) => {
-        if !$self.check_initialized().await {
-            return Self::uninitialized();
-        }
-    };
-}
-
 mod mcp_utils;
 mod tools;
 
 use crate::{Config, Mode};
 use rmcp::handler::server::tool::ToolRouter;
-use rmcp::model::{
-    CallToolResult, Implementation, ProtocolVersion, ServerCapabilities, ServerInfo,
-};
+use rmcp::model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo};
 use rmcp::transport::stdio;
-use rmcp::ErrorData as McpError;
 use rmcp::{tool_handler, ServerHandler, ServiceExt};
 use std::sync::Arc;
-use tokio::sync::Mutex;
 use tracing::info;
 
 /// The tiller MCP server.
@@ -32,7 +19,6 @@ use tracing::info;
 /// This server exposes tiller sync functionality as MCP tools.
 #[derive(Debug, Clone)]
 pub struct TillerServer {
-    initialized: Arc<Mutex<bool>>,
     mode: Mode,
     config: Arc<Config>,
     tool_router: ToolRouter<TillerServer>,
@@ -42,21 +28,10 @@ impl TillerServer {
     /// Creates a new TillerServer with the given configuration.
     pub fn new(config: Config, mode: Mode) -> Self {
         Self {
-            initialized: Arc::new(Mutex::new(false)),
             mode,
             config: Arc::new(config),
             tool_router: Self::tool_router(),
         }
-    }
-
-    async fn check_initialized(&self) -> bool {
-        *self.initialized.lock().await
-    }
-
-    fn uninitialized() -> Result<CallToolResult, McpError> {
-        Ok(CallToolResult::error(vec![rmcp::model::ContentBlock::text(
-            "You have not yet initialized the service. Please call __initialize_service__ first.",
-        )]))
     }
 }
 
@@ -64,11 +39,10 @@ impl TillerServer {
 impl ServerHandler for TillerServer {
     /// Returns server information sent to the MCP client during initialization.
     ///
-    /// The `instructions` field is intended by the specification to be the primary way to
-    /// communicate the server's purpose and usage to AI agents like Claude Code. This text is shown
-    /// to the AI to help it understand when and how to use this server's tools. However, it has
-    /// been noted that agents tend to consider this reading as optional. We have solved this
-    /// problem by requiring agents to call an `__initialize_service__` tool before anything else.
+    /// The `instructions` field is the specification's way of telling an AI client what this
+    /// server is for. It is deliberately short: the client pays for it in context on every session,
+    /// whether or not tiller ends up being used. The in-depth guide lives behind the `instructions`
+    /// tool, which the agent can call when it wants the detail.
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
             .with_instructions(include_str!("docs/INTRO.md"));
@@ -137,7 +111,7 @@ mod tests {
     use tokio::io::duplex;
 
     /// Integration test for the MCP server using an in-memory transport.
-    /// Tests initialize_service, sync_down, and sync_up tools.
+    /// Tests the sync_down, sync_up and update_transactions tools.
     #[tokio::test]
     async fn test_mcp_server_integration() {
         // Create duplex channel - one end for server, one for client
@@ -156,21 +130,8 @@ mod tests {
         // Create MCP client connected to the other end
         let client = ().serve(client_io).await.expect("Failed to create client");
 
-        // Test 1: Call initialize_service tool
-        let init_result = client
-            .call_tool(rmcp::model::CallToolRequestParams::new(
-                "initialize_service",
-            ))
-            .await
-            .expect("initialize_service call failed");
-
-        assert!(
-            !init_result.is_error.unwrap_or(false),
-            "initialize_service returned error: {:?}",
-            init_result.content
-        );
-
-        // Test 2: Call sync_down tool
+        // Test 1: sync_down works without any prior "initialization" call. The server used to
+        // reject every tool until `initialize_service` had been called at least once.
         let sync_down_result = client
             .call_tool(rmcp::model::CallToolRequestParams::new("sync_down"))
             .await
@@ -182,7 +143,7 @@ mod tests {
             sync_down_result.content
         );
 
-        // Test 3: Call sync_up tool with force and formulas params
+        // Test 2: Call sync_up tool with force and formulas params
         let mut args = serde_json::Map::new();
         args.insert("force".into(), serde_json::Value::Bool(true));
         args.insert(
@@ -201,7 +162,7 @@ mod tests {
             sync_up_result.content
         );
 
-        // Test 4: Call update_transaction tool
+        // Test 3: Call update_transaction tool
         // After sync_down, we have transactions in the database. Get one to update.
         let tiller_data = env.config().db().get_tiller_data().await.unwrap();
         let first_txn = &tiller_data.transactions.data()[0];
@@ -244,6 +205,50 @@ mod tests {
             server_result.is_ok(),
             "Server returned error: {:?}",
             server_result
+        );
+    }
+
+    /// The server used to reject every tool call until `initialize_service` had been called,
+    /// which forced a help lookup before any real work could start. Tools are now callable
+    /// straight away, like any other MCP server.
+    #[tokio::test]
+    async fn test_tools_need_no_initialization_call() {
+        let (client_io, server_io) = duplex(4096);
+        let env = TestEnv::new().await;
+        let config = env.config();
+
+        let _server_handle =
+            tokio::spawn(
+                async move { run_server(config, Mode::Testing, Io::Mock(server_io)).await },
+            );
+        let client = ().serve(client_io).await.expect("Failed to create client");
+
+        let tools = client
+            .list_tools(Default::default())
+            .await
+            .expect("Failed to list tools");
+        let names: Vec<&str> = tools.tools.iter().map(|t| t.name.as_ref()).collect();
+
+        assert!(
+            !names.contains(&"initialize_service"),
+            "the initialization tool should be gone, found: {names:?}"
+        );
+        assert!(
+            names.contains(&"instructions"),
+            "the in-depth guide should still be reachable, found: {names:?}"
+        );
+
+        // Every tool must work as the very first call of the session. `schema` is the cheapest one
+        // that touches real state.
+        let result = client
+            .call_tool(rmcp::model::CallToolRequestParams::new("schema"))
+            .await
+            .expect("schema call failed");
+
+        assert!(
+            !result.is_error.unwrap_or(false),
+            "a tool called before anything else should succeed, got: {:?}",
+            result.content
         );
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -2,8 +2,8 @@
 
 use crate::args::{
     DeleteAutoCatsArgs, DeleteCategoriesArgs, DeleteTransactionsArgs, InsertAutoCatArgs,
-    InsertCategoryArgs, InsertTransactionArgs, QueryArgs, SchemaArgs, UpdateAutoCatsArgs,
-    UpdateCategoriesArgs, UpdateTransactionsArgs,
+    InsertCategoryArgs, InsertTransactionArgs, QueryArgs, SchemaArgs, StatusArgs,
+    UpdateAutoCatsArgs, UpdateCategoriesArgs, UpdateTransactionsArgs,
 };
 use crate::commands::{self, FormulasMode};
 use crate::mcp::mcp_utils::tool_result;
@@ -15,6 +15,17 @@ use rmcp::{tool, tool_router};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tracing::info;
+
+/// Parameters for the sync_down tool.
+#[derive(Debug, Deserialize, JsonSchema)]
+#[schemars(title = "SyncDownParams")]
+pub struct SyncDownParams {
+    /// Discard local edits that have not been uploaded to the sheet. Without this, sync_down
+    /// refuses to run when the local database has unsynced changes, so that downloading cannot
+    /// silently destroy them.
+    #[serde(default)]
+    pub force: bool,
+}
 
 /// Parameters for the sync_up tool.
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -70,14 +81,53 @@ impl TillerServer {
     ///
     /// # Caution
     ///
-    /// This operation overwrites local changes with sheet data. If you have local modifications
-    /// that haven't been synced up, they will be lost. The SQLite backup allows manual recovery
-    /// if needed.
+    /// This operation overwrites local changes with sheet data. To avoid discarding work, it
+    /// refuses to run when the local database has edits that have not been uploaded, and names
+    /// what would be lost. Run `sync_up` first to upload them, or set `force=true` to discard
+    /// them deliberately. The SQLite backup allows manual recovery if needed.
+    ///
+    /// Use `sync_status` to see whether the sheet has changed without downloading it.
+    ///
+    /// # Parameters
+    ///
+    /// - `force`: Discard local edits that have not been uploaded. Default `false`.
     #[tool]
-    async fn sync_down(&self) -> Result<CallToolResult, McpError> {
-        info!("MCP: sync_down called");
+    async fn sync_down(
+        &self,
+        Parameters(params): Parameters<SyncDownParams>,
+    ) -> Result<CallToolResult, McpError> {
+        info!("MCP: sync_down called with force={}", params.force);
         let config = (*self.config).clone();
-        let out = commands::sync_down(config, self.mode).await;
+        let out = commands::sync_down(config, self.mode, params.force).await;
+        tool_result(out)
+    }
+
+    /// Report what has changed in the local database and in the Google Sheet since the last sync,
+    /// without modifying either.
+    ///
+    /// Use this to decide which way to sync, and to check whether the sheet has moved on without
+    /// running `sync_down` (which would discard unsynced local edits).
+    ///
+    /// # Parameters
+    ///
+    /// - `local_only`: Skip reading the Google Sheet and report local changes only. Reading the
+    ///   sheet needs network access and valid authentication. Default `false`.
+    ///
+    /// # Returns
+    ///
+    /// - `synced_before`: false when no sync has ever run, in which case there is nothing to
+    ///   compare against.
+    /// - `local`: rows added, modified, and deleted locally since the last sync. `sync_down` would
+    ///   discard these.
+    /// - `remote`: the same counts for the Google Sheet. `sync_up` would overwrite these. Absent
+    ///   when `local_only` is true.
+    #[tool]
+    async fn sync_status(
+        &self,
+        Parameters(args): Parameters<StatusArgs>,
+    ) -> Result<CallToolResult, McpError> {
+        let config = (*self.config).clone();
+        let out = commands::status(config, self.mode, !args.local_only).await;
         tool_result(out)
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -33,14 +33,14 @@ pub struct SyncUpParams {
 
 #[tool_router(vis = "pub(super)")]
 impl TillerServer {
+    /// Return the in-depth usage guide for this server.
+    ///
+    /// Optional. Every tool here documents its own parameters and behavior, so this is only worth
+    /// calling when you want the wider picture: the sync workflow, what each backup file is for,
+    /// how conflict detection and formula handling interact, the database schema, and example
+    /// queries.
     #[tool]
-    /// Initialize the tiller MCP service for this session and return usage instructions. You
-    /// **MUST** call this **ONCE** before using other tools so that you have the full usage
-    /// instructions. You **MAY** call it more than once if you have forgotten the usage
-    /// instructions.
-    async fn initialize_service(&self) -> Result<CallToolResult, McpError> {
-        let mut initialized = self.initialized.lock().await;
-        *initialized = true;
+    async fn instructions(&self) -> Result<CallToolResult, McpError> {
         Ok(CallToolResult::success(vec![
             rmcp::model::ContentBlock::text(include_str!("docs/INSTRUCTIONS.md")),
         ]))
@@ -75,7 +75,6 @@ impl TillerServer {
     /// if needed.
     #[tool]
     async fn sync_down(&self) -> Result<CallToolResult, McpError> {
-        require_init!(self);
         info!("MCP: sync_down called");
         let config = (*self.config).clone();
         let out = commands::sync_down(config, self.mode).await;
@@ -150,8 +149,6 @@ impl TillerServer {
         &self,
         Parameters(params): Parameters<SyncUpParams>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         info!(
             "MCP: sync_up called with force={}, formulas={}",
             params.force, params.formulas
@@ -205,8 +202,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateTransactionsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_transactions(config, args).await;
         tool_result(out)
@@ -265,8 +260,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateCategoriesArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_categories(config, args).await;
         tool_result(out)
@@ -327,8 +320,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<UpdateAutoCatsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::update_autocats(config, args).await;
         tool_result(out)
@@ -381,8 +372,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteTransactionsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_transactions(config, args).await;
         tool_result(out)
@@ -442,8 +431,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteCategoriesArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_categories(config, args).await;
         tool_result(out)
@@ -499,8 +486,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<DeleteAutoCatsArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::delete_autocats(config, args).await;
         tool_result(out)
@@ -559,8 +544,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertTransactionArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_transaction(config, args).await;
         tool_result(out)
@@ -612,8 +595,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertCategoryArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_category(config, args).await;
         tool_result(out)
@@ -692,8 +673,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<InsertAutoCatArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::insert_autocat(config, args).await;
         tool_result(out)
@@ -750,8 +729,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<QueryArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::query(config, args).await;
         tool_result(out)
@@ -820,8 +797,6 @@ impl TillerServer {
         &self,
         Parameters(args): Parameters<SchemaArgs>,
     ) -> Result<CallToolResult, McpError> {
-        require_init!(self);
-
         let config = (*self.config).clone();
         let out = commands::schema(config, args).await;
         tool_result(out)

--- a/src/model/changes.rs
+++ b/src/model/changes.rs
@@ -1,0 +1,343 @@
+//! Comparing two `TillerData` snapshots.
+//!
+//! Used to answer two questions that look the same but are asked at different moments:
+//!
+//! - Before `sync down`: has the local datastore been edited since it was last in step with the
+//!   sheet? If so, downloading would overwrite those edits.
+//! - Before `sync up`: has the sheet been edited since it was last downloaded? If so, uploading
+//!   would overwrite those edits.
+//!
+//! See <https://github.com/webern/tiller-sync/issues/38>.
+
+use crate::model::items::Item;
+use crate::model::{AutoCats, Categories, TillerData, Transactions};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::fmt::{Display, Formatter};
+
+/// How one tab differs between two snapshots.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct TabChanges {
+    /// Rows present in the newer snapshot but not the older one.
+    pub added: usize,
+    /// Rows present in both, with at least one differing cell.
+    pub modified: usize,
+    /// Rows present in the older snapshot but not the newer one.
+    pub removed: usize,
+}
+
+impl TabChanges {
+    pub fn is_empty(&self) -> bool {
+        self.added == 0 && self.modified == 0 && self.removed == 0
+    }
+
+    fn total(&self) -> usize {
+        self.added + self.modified + self.removed
+    }
+}
+
+/// How two `TillerData` snapshots differ, tab by tab.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct Changes {
+    /// Differences in the Transactions tab.
+    pub transactions: TabChanges,
+    /// Differences in the Categories tab.
+    pub categories: TabChanges,
+    /// Differences in the AutoCat tab.
+    pub auto_cats: TabChanges,
+}
+
+impl Changes {
+    /// Compares `newer` against `older`, describing what `newer` did to `older`.
+    pub(crate) fn between(older: &TillerData, newer: &TillerData) -> Self {
+        Self {
+            transactions: transaction_changes(&older.transactions, &newer.transactions),
+            categories: category_changes(&older.categories, &newer.categories),
+            auto_cats: auto_cat_changes(&older.auto_cats, &newer.auto_cats),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.transactions.is_empty() && self.categories.is_empty() && self.auto_cats.is_empty()
+    }
+}
+
+impl Display for Changes {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        if self.is_empty() {
+            return write!(f, "no changes");
+        }
+
+        let mut parts = Vec::new();
+        for (name, tab) in [
+            ("transaction", self.transactions),
+            ("category", self.categories),
+            ("autocat rule", self.auto_cats),
+        ] {
+            if tab.is_empty() {
+                continue;
+            }
+            parts.push(format!(
+                "{} {name}{} ({} added, {} modified, {} deleted)",
+                tab.total(),
+                if tab.total() == 1 { "" } else { "s" },
+                tab.added,
+                tab.modified,
+                tab.removed
+            ));
+        }
+        write!(f, "{}", parts.join(", "))
+    }
+}
+
+/// Comparison uses each row's sheet representation rather than its in-memory fields.
+///
+/// A row's sheet representation is the canonical form of the data: it is exactly what a `sync up`
+/// would write and exactly what a `sync down` parsed. Comparing typed fields instead would report
+/// differences for values that round-trip through the database with a different but equivalent
+/// representation, which would make the check cry wolf and get ignored.
+fn rows<I>(items: &[I], headers: &[String]) -> Vec<Vec<String>>
+where
+    I: Item,
+{
+    items.iter().map(|item| item.to_row(headers)).collect()
+}
+
+/// The headers to compare a tab's rows across: the sheet's own columns.
+///
+/// Deliberately not "every field the model has". A field with no column in the sheet cannot be
+/// uploaded, so reporting an edit to it would produce a difference that no `sync up` could ever
+/// clear, and `sync down` would be blocked forever. The comparison measures what a sync can
+/// actually carry.
+///
+/// The unnamed column A that some sheets have is dropped for the opposite reason: it has no
+/// database column, so it reads back empty and would make every row look modified.
+fn headers_of(mapping: &crate::model::Mapping) -> Vec<String> {
+    mapping
+        .headers()
+        .iter()
+        .map(|h| h.as_ref().to_string())
+        .filter(|h| !h.is_empty())
+        .collect()
+}
+
+/// Compares two keyed tabs, where `key` extracts a stable identity for a row.
+fn keyed_changes(
+    older: Vec<(String, Vec<String>)>,
+    newer: Vec<(String, Vec<String>)>,
+) -> TabChanges {
+    let older: BTreeMap<String, Vec<String>> = older.into_iter().collect();
+    let newer: BTreeMap<String, Vec<String>> = newer.into_iter().collect();
+
+    let mut changes = TabChanges::default();
+    for (key, new_row) in &newer {
+        match older.get(key) {
+            None => changes.added += 1,
+            Some(old_row) if old_row != new_row => changes.modified += 1,
+            Some(_) => {}
+        }
+    }
+    changes.removed = older.keys().filter(|key| !newer.contains_key(*key)).count();
+    changes
+}
+
+fn transaction_changes(older: &Transactions, newer: &Transactions) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let keyed = |items: &Transactions| -> Vec<(String, Vec<String>)> {
+        items
+            .data()
+            .iter()
+            .map(|t| t.transaction_id.clone())
+            .zip(rows(items.data(), &headers))
+            .collect()
+    };
+    keyed_changes(keyed(older), keyed(newer))
+}
+
+fn category_changes(older: &Categories, newer: &Categories) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let keyed = |items: &Categories| -> Vec<(String, Vec<String>)> {
+        items
+            .data()
+            .iter()
+            .map(|c| c.category.clone())
+            .zip(rows(items.data(), &headers))
+            .collect()
+    };
+    keyed_changes(keyed(older), keyed(newer))
+}
+
+/// AutoCat rules have no stable identity: their primary key is a synthetic auto-increment that is
+/// reassigned on every `sync down`, because the whole tab is replaced. Rules are therefore compared
+/// as a multiset of their sheet rows, which reports a reordering as no change at all. That is the
+/// right answer here: the question is whether rules were gained or lost, and the sheet's own row
+/// order is not something the user edits meaningfully.
+fn auto_cat_changes(older: &AutoCats, newer: &AutoCats) -> TabChanges {
+    let headers = headers_of(newer.mapping());
+    let counted = |items: &AutoCats| -> BTreeMap<Vec<String>, usize> {
+        let mut counts = BTreeMap::new();
+        for row in rows(items.data(), &headers) {
+            *counts.entry(row).or_default() += 1;
+        }
+        counts
+    };
+    let older = counted(older);
+    let newer = counted(newer);
+
+    let mut changes = TabChanges::default();
+    for (row, new_count) in &newer {
+        let old_count = older.get(row).copied().unwrap_or(0);
+        changes.added += new_count.saturating_sub(old_count);
+    }
+    for (row, old_count) in &older {
+        let new_count = newer.get(row).copied().unwrap_or(0);
+        changes.removed += old_count.saturating_sub(new_count);
+    }
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{AutoCats, Categories, Transactions};
+
+    fn transactions(rows: &[(&str, &str, &str)]) -> Transactions {
+        let mut sheet = vec![vec![
+            "Transaction ID".to_string(),
+            "Date".to_string(),
+            "Amount".to_string(),
+            "Category".to_string(),
+        ]];
+        for (id, amount, category) in rows {
+            sheet.push(vec![
+                id.to_string(),
+                "2025-01-01".to_string(),
+                amount.to_string(),
+                category.to_string(),
+            ]);
+        }
+        Transactions::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn categories(names: &[&str]) -> Categories {
+        let mut sheet = vec![vec!["Category".to_string(), "Group".to_string()]];
+        for name in names {
+            sheet.push(vec![name.to_string(), "Everyday".to_string()]);
+        }
+        Categories::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn auto_cats(contains: &[&str]) -> AutoCats {
+        let mut sheet = vec![vec![
+            "Category".to_string(),
+            "Description Contains".to_string(),
+        ]];
+        for text in contains {
+            sheet.push(vec!["Groceries".to_string(), text.to_string()]);
+        }
+        AutoCats::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    fn data(
+        txns: &[(&str, &str, &str)],
+        cats: &[&str],
+        rules: &[&str],
+    ) -> crate::model::TillerData {
+        crate::model::TillerData {
+            transactions: transactions(txns),
+            categories: categories(cats),
+            auto_cats: auto_cats(rules),
+        }
+    }
+
+    #[test]
+    fn test_identical_data_has_no_changes() {
+        let a = data(&[("t1", "-1.00", "Food")], &["Food"], &["starbucks"]);
+        let b = data(&[("t1", "-1.00", "Food")], &["Food"], &["starbucks"]);
+        let changes = Changes::between(&a, &b);
+        assert!(changes.is_empty(), "got: {changes}");
+        assert_eq!(changes.to_string(), "no changes");
+    }
+
+    /// Recategorizing a transaction is the edit the reporter nearly lost.
+    #[test]
+    fn test_recategorizing_counts_as_a_modification() {
+        let before = data(&[("t1", "-1.00", "")], &["Food"], &[]);
+        let after = data(&[("t1", "-1.00", "Food")], &["Food"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.transactions.modified, 1);
+        assert_eq!(changes.transactions.added, 0);
+        assert_eq!(changes.transactions.removed, 0);
+        assert!(changes.categories.is_empty());
+    }
+
+    #[test]
+    fn test_added_and_removed_transactions() {
+        let before = data(&[("t1", "-1.00", "Food")], &["Food"], &[]);
+        let after = data(&[("t2", "-2.00", "Food")], &["Food"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.transactions.added, 1);
+        assert_eq!(changes.transactions.removed, 1);
+        assert_eq!(changes.transactions.modified, 0);
+    }
+
+    /// AutoCat rules added locally are the other thing the reporter nearly lost, and they have no
+    /// stable key to match on.
+    #[test]
+    fn test_added_autocat_rules() {
+        let before = data(&[], &["Groceries"], &["starbucks"]);
+        let after = data(&[], &["Groceries"], &["starbucks", "peets", "blue bottle"]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.auto_cats.added, 2);
+        assert_eq!(changes.auto_cats.removed, 0);
+    }
+
+    #[test]
+    fn test_removed_autocat_rules() {
+        let before = data(&[], &["Groceries"], &["starbucks", "peets"]);
+        let after = data(&[], &["Groceries"], &["starbucks"]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.auto_cats.removed, 1);
+        assert_eq!(changes.auto_cats.added, 0);
+    }
+
+    /// Reordering the AutoCat tab is not a change worth blocking a sync over.
+    #[test]
+    fn test_reordered_autocat_rules_are_not_changes() {
+        let before = data(&[], &["Groceries"], &["starbucks", "peets"]);
+        let after = data(&[], &["Groceries"], &["peets", "starbucks"]);
+        let changes = Changes::between(&before, &after);
+
+        assert!(changes.auto_cats.is_empty(), "got: {changes}");
+    }
+
+    #[test]
+    fn test_category_changes() {
+        let before = data(&[], &["Food", "Gas"], &[]);
+        let after = data(&[], &["Food", "Fuel"], &[]);
+        let changes = Changes::between(&before, &after);
+
+        assert_eq!(changes.categories.added, 1);
+        assert_eq!(changes.categories.removed, 1);
+    }
+
+    #[test]
+    fn test_display_summarizes_every_tab() {
+        let before = data(&[("t1", "-1.00", "")], &["Food"], &[]);
+        let after = data(
+            &[("t1", "-1.00", "Food"), ("t2", "-2.00", "Food")],
+            &["Food", "Gas"],
+            &["shell"],
+        );
+        let summary = Changes::between(&before, &after).to_string();
+
+        assert!(summary.contains("2 transactions"), "got: {summary}");
+        assert!(summary.contains("1 category"), "got: {summary}");
+        assert!(summary.contains("1 autocat rule"), "got: {summary}");
+    }
+}

--- a/src/model/items.rs
+++ b/src/model/items.rs
@@ -247,6 +247,10 @@ where
         &self.data
     }
 
+    pub(crate) fn data_mut(&mut self) -> &mut Vec<I> {
+        &mut self.data
+    }
+
     pub fn mapping(&self) -> &Mapping {
         &self.mapping
     }

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -7,6 +7,7 @@ mod items;
 mod mapping;
 mod row_col;
 mod transaction;
+mod transaction_ids;
 
 pub use amount::{Amount, AmountFormat};
 pub use auto_cat::{AutoCat, AutoCatUpdates, AutoCats};
@@ -18,6 +19,7 @@ pub(crate) use mapping::Mapping;
 pub(crate) use row_col::RowCol;
 use serde::{Deserialize, Serialize};
 pub use transaction::{Transaction, TransactionColumn, TransactionUpdates, Transactions};
+pub(crate) use transaction_ids::resolve_transaction_ids;
 
 /// Represents all the sheets of interest from a tiller Google sheet.
 #[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -2,6 +2,7 @@
 mod amount;
 mod auto_cat;
 mod category;
+mod changes;
 mod date;
 mod items;
 mod mapping;
@@ -12,6 +13,7 @@ mod transaction_ids;
 pub use amount::{Amount, AmountFormat};
 pub use auto_cat::{AutoCat, AutoCatUpdates, AutoCats};
 pub use category::{Categories, Category, CategoryUpdates};
+pub use changes::{Changes, TabChanges};
 pub use date::Date;
 pub(crate) use date::{DateFromOpt, DateFromOptStr, DateToSheetStr};
 pub(crate) use items::Item;

--- a/src/model/transaction.rs
+++ b/src/model/transaction.rs
@@ -102,6 +102,15 @@ pub struct Transaction {
     /// Used for formula preservation during sync up.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) original_order: Option<u64>,
+
+    /// The Transaction ID exactly as it appeared in the sheet, kept only when that value could not
+    /// serve as a primary key because it was blank or duplicated. In that case `transaction_id`
+    /// holds a surrogate `user-` ID and this field holds the sheet's value, which is what gets
+    /// written back on sync up so the sheet round-trips unchanged.
+    ///
+    /// None in the ordinary case, where `transaction_id` is the sheet's own value.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) original_transaction_id: Option<String>,
 }
 
 impl Item for Transaction {
@@ -152,7 +161,12 @@ impl Item for Transaction {
     fn get_by_header(&self, header: &str) -> String {
         match TransactionColumn::from_header(header) {
             Ok(col) => match col {
-                TransactionColumn::TransactionId => self.transaction_id.clone(),
+                // A row whose sheet value could not be a primary key was given a surrogate. Write
+                // the sheet's own value back so the Transactions tab round-trips unchanged.
+                TransactionColumn::TransactionId => self
+                    .original_transaction_id
+                    .clone()
+                    .unwrap_or_else(|| self.transaction_id.clone()),
                 TransactionColumn::Date => self.date.d_to_s(Y::Y4),
                 TransactionColumn::Description => self.description.clone(),
                 TransactionColumn::Amount => self.amount.to_string(),

--- a/src/model/transaction_ids.rs
+++ b/src/model/transaction_ids.rs
@@ -1,0 +1,424 @@
+//! Making the `Transaction ID` column usable as a primary key.
+//!
+//! `transactions.transaction_id` is the primary key of the local datastore, but real Tiller sheets
+//! routinely contain rows whose `Transaction ID` cannot serve as one:
+//!
+//! - **Blank.** Some feeds supply no ID at all. Apple Card is the well-known example, and it can
+//!   account for hundreds of rows in an ordinary sheet.
+//! - **Duplicated.** Malformed split markers such as `split:[1]` and `split:[2]` appear verbatim in
+//!   the column, on every split row, instead of referencing the parent transaction's ID.
+//!
+//! Neither case means the row is corrupt, so refusing to sync would make the tool unusable against
+//! an ordinary sheet. Instead, every affected row is given a surrogate `user-` ID and the sheet's
+//! own value is kept in `original_transaction_id`, which is what gets written back on sync up. The
+//! round trip therefore leaves the Transactions tab byte-for-byte unchanged.
+//!
+//! See <https://github.com/webern/tiller-sync/issues/37>.
+
+use crate::model::{Transaction, Transactions};
+use std::collections::{BTreeMap, BTreeSet};
+use tracing::{debug, warn};
+
+/// The most offending rows to name individually before summarizing the rest.
+const MAX_REPORTED_ROWS: usize = 10;
+
+/// Why a row's `Transaction ID` could not be used as a primary key.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum IdProblem {
+    /// The column was empty.
+    Blank,
+    /// More than one row carried this value.
+    Duplicate,
+}
+
+impl IdProblem {
+    fn describe(&self) -> &'static str {
+        match self {
+            IdProblem::Blank => "blank",
+            IdProblem::Duplicate => "duplicated",
+        }
+    }
+}
+
+/// One row that was given a surrogate ID.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub(crate) struct ResolvedId {
+    /// The row's position in the sheet, 1-based and counting the header, so it matches what the
+    /// user sees in Google Sheets.
+    pub(crate) sheet_row: u64,
+    /// The value that was in the `Transaction ID` column.
+    pub(crate) original: String,
+    /// The surrogate now used as the primary key.
+    pub(crate) surrogate: String,
+    /// Why a surrogate was needed.
+    pub(crate) problem: IdProblem,
+}
+
+/// What [`resolve_transaction_ids`] had to change.
+#[derive(Debug, Clone, Default, Eq, PartialEq)]
+pub(crate) struct IdReport {
+    pub(crate) resolved: Vec<ResolvedId>,
+}
+
+impl IdReport {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.resolved.is_empty()
+    }
+
+    fn count(&self, problem: IdProblem) -> usize {
+        self.resolved
+            .iter()
+            .filter(|r| r.problem == problem)
+            .count()
+    }
+
+    /// Tells the user what happened.
+    ///
+    /// The whole point of this over the old behavior is that the user learns about *every* offending
+    /// row rather than whichever one SQLite happened to reject first. The first few are named
+    /// individually and the rest are counted, with a pointer at the query that lists them all.
+    pub(crate) fn log(&self) {
+        if self.is_empty() {
+            return;
+        }
+
+        let blank = self.count(IdProblem::Blank);
+        let duplicate = self.count(IdProblem::Duplicate);
+
+        warn!(
+            "{} of the sheet's rows have a Transaction ID that cannot be used as a key \
+             ({blank} blank, {duplicate} duplicated). Each was given a surrogate `user-` ID for \
+             local use. The sheet's own value is preserved and written back unchanged on sync up. \
+             To list them: SELECT original_transaction_id, transaction_id, date, description FROM \
+             transactions WHERE original_transaction_id IS NOT NULL",
+            self.resolved.len()
+        );
+
+        for resolved in self.resolved.iter().take(MAX_REPORTED_ROWS) {
+            debug!(
+                "Sheet row {}: {} Transaction ID {:?} -> {}",
+                resolved.sheet_row,
+                resolved.problem.describe(),
+                resolved.original,
+                resolved.surrogate
+            );
+        }
+
+        if self.resolved.len() > MAX_REPORTED_ROWS {
+            debug!(
+                "...and {} more rows with an unusable Transaction ID",
+                self.resolved.len() - MAX_REPORTED_ROWS
+            );
+        }
+    }
+}
+
+/// Gives a surrogate `user-` ID to every row whose `Transaction ID` cannot be a primary key,
+/// returning a report of what changed.
+///
+/// A surrogate has to be **stable** across syncs. `sync down` upserts on `transaction_id`, so an ID
+/// that changed from one sync to the next would make the row look deleted and re-added, discarding
+/// any local edits on it. The surrogate is therefore derived from the row's own content rather than
+/// from its position, which shifts whenever a row is added above it.
+///
+/// Rows that are identical in content would hash the same, so the occurrence number within a group
+/// of identical rows is mixed in as well.
+pub(crate) fn resolve_transaction_ids(transactions: &mut Transactions) -> IdReport {
+    // Which sheet values appear more than once. A blank is handled separately: it is unusable even
+    // when it appears only once.
+    let mut counts: BTreeMap<&str, usize> = BTreeMap::new();
+    for transaction in transactions.data() {
+        *counts
+            .entry(transaction.transaction_id.as_str())
+            .or_default() += 1;
+    }
+    let duplicated: BTreeSet<String> = counts
+        .into_iter()
+        .filter(|(id, count)| *count > 1 && !id.trim().is_empty())
+        .map(|(id, _)| id.to_string())
+        .collect();
+
+    let mut report = IdReport::default();
+    let mut occurrences: BTreeMap<String, u32> = BTreeMap::new();
+
+    for (index, transaction) in transactions.data_mut().iter_mut().enumerate() {
+        let original = transaction.transaction_id.clone();
+        let problem = if original.trim().is_empty() {
+            IdProblem::Blank
+        } else if duplicated.contains(&original) {
+            IdProblem::Duplicate
+        } else {
+            continue;
+        };
+
+        let fingerprint = fingerprint(transaction);
+        let occurrence = occurrences.entry(fingerprint.clone()).or_default();
+        let surrogate = surrogate_id(&fingerprint, *occurrence);
+        *occurrence += 1;
+
+        transaction.original_transaction_id = Some(original.clone());
+        transaction.transaction_id = surrogate.clone();
+
+        report.resolved.push(ResolvedId {
+            // +2: the sheet is 1-based and the first row is the header.
+            sheet_row: index as u64 + 2,
+            original,
+            surrogate,
+            problem,
+        });
+    }
+
+    report
+}
+
+/// The row content that a surrogate ID is derived from.
+///
+/// Only fields that come from the bank are used. Anything the user can edit locally, such as the
+/// category or a note, is left out, because editing it would otherwise change the row's key and
+/// make the row look like a different one on the next sync.
+///
+/// The amount contributes its numeric value rather than its `Display`, which carries the formatting
+/// the value was parsed from — a dollar sign, thousands separators. Reformatting the Amount column
+/// in the sheet does not change what the row is, so it must not change the row's key.
+fn fingerprint(transaction: &Transaction) -> String {
+    format!(
+        "{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}\u{1f}{}",
+        transaction
+            .original_transaction_id
+            .as_deref()
+            .unwrap_or(&transaction.transaction_id),
+        transaction.date,
+        transaction.amount.value(),
+        transaction.description,
+        transaction.full_description,
+        transaction.account,
+        transaction.institution,
+    )
+}
+
+/// Builds the surrogate ID for a fingerprint and its occurrence number.
+///
+/// The `user-` prefix is the project's existing marker for an ID that Tiller did not assign.
+fn surrogate_id(fingerprint: &str, occurrence: u32) -> String {
+    let hash = fnv1a_64(format!("{fingerprint}\u{1f}{occurrence}").as_bytes());
+    format!("user-{hash:016x}")
+}
+
+/// FNV-1a, 64-bit.
+///
+/// Written out rather than taken from `std::hash::DefaultHasher` because these hashes are persisted
+/// as primary keys: the standard hasher's algorithm is explicitly allowed to change between Rust
+/// releases, which would silently re-key every affected row. This is a fixed, specified algorithm
+/// that will produce the same output forever.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = OFFSET_BASIS;
+    for byte in bytes {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(PRIME);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Transactions;
+
+    const HEADERS: &[&str] = &[
+        "Transaction ID",
+        "Date",
+        "Description",
+        "Amount",
+        "Account",
+        "Institution",
+    ];
+
+    /// Builds a `Transactions` from `(id, date, description, amount)` tuples.
+    fn transactions(rows: &[(&str, &str, &str, &str)]) -> Transactions {
+        let mut sheet: Vec<Vec<String>> = vec![HEADERS.iter().map(|h| h.to_string()).collect()];
+        for (id, date, description, amount) in rows {
+            sheet.push(vec![
+                id.to_string(),
+                date.to_string(),
+                description.to_string(),
+                amount.to_string(),
+                "Apple Card".to_string(),
+                "Apple".to_string(),
+            ]);
+        }
+        Transactions::parse(sheet, Vec::<Vec<String>>::new()).unwrap()
+    }
+
+    #[test]
+    fn test_unique_ids_are_left_alone() {
+        let mut txns = transactions(&[
+            ("69112cec0a57f52108456b88", "2025-01-01", "One", "-1.00"),
+            ("690edd882cac40d381f9e518", "2025-01-02", "Two", "-2.00"),
+        ]);
+
+        let report = resolve_transaction_ids(&mut txns);
+
+        assert!(report.is_empty());
+        assert_eq!(
+            txns.data()[0].transaction_id,
+            "69112cec0a57f52108456b88",
+            "an ordinary ID should be untouched"
+        );
+        assert!(txns.data()[0].original_transaction_id.is_none());
+    }
+
+    #[test]
+    fn test_blank_ids_get_surrogates() {
+        let mut txns = transactions(&[
+            ("", "2025-01-01", "Apple Card One", "-1.00"),
+            ("", "2025-01-02", "Apple Card Two", "-2.00"),
+        ]);
+
+        let report = resolve_transaction_ids(&mut txns);
+
+        assert_eq!(report.resolved.len(), 2);
+        assert_eq!(report.count(IdProblem::Blank), 2);
+        for transaction in txns.data() {
+            assert!(transaction.transaction_id.starts_with("user-"));
+            assert_eq!(transaction.original_transaction_id.as_deref(), Some(""));
+        }
+        assert_ne!(
+            txns.data()[0].transaction_id,
+            txns.data()[1].transaction_id,
+            "two blank rows must not collide"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_ids_get_surrogates() {
+        let mut txns = transactions(&[
+            ("split:[1]", "2025-01-01", "Split A", "-1.00"),
+            ("split:[2]", "2025-01-01", "Split B", "-2.00"),
+            ("split:[1]", "2025-02-01", "Split C", "-3.00"),
+        ]);
+
+        let report = resolve_transaction_ids(&mut txns);
+
+        // Both rows carrying `split:[1]` are rewritten. `split:[2]` appears once, so it stays.
+        assert_eq!(report.resolved.len(), 2);
+        assert_eq!(report.count(IdProblem::Duplicate), 2);
+        assert_eq!(txns.data()[1].transaction_id, "split:[2]");
+        assert_eq!(
+            txns.data()[0].original_transaction_id.as_deref(),
+            Some("split:[1]")
+        );
+        assert_eq!(
+            txns.data()[2].original_transaction_id.as_deref(),
+            Some("split:[1]")
+        );
+        assert_ne!(txns.data()[0].transaction_id, txns.data()[2].transaction_id);
+    }
+
+    /// Identical rows are plausible: the same card, the same merchant, the same amount, the same
+    /// day. They still need distinct keys.
+    #[test]
+    fn test_identical_rows_get_distinct_surrogates() {
+        let mut txns = transactions(&[
+            ("", "2025-01-01", "Coffee", "-4.50"),
+            ("", "2025-01-01", "Coffee", "-4.50"),
+            ("", "2025-01-01", "Coffee", "-4.50"),
+        ]);
+
+        resolve_transaction_ids(&mut txns);
+
+        let ids: std::collections::BTreeSet<&str> = txns
+            .data()
+            .iter()
+            .map(|t| t.transaction_id.as_str())
+            .collect();
+        assert_eq!(
+            ids.len(),
+            3,
+            "three identical rows need three distinct keys"
+        );
+    }
+
+    /// A surrogate is a primary key, so it has to survive a re-sync. If it were derived from the
+    /// row's position, inserting a row above it would re-key it and the upsert would treat the row
+    /// as deleted and re-added, losing any local edits.
+    #[test]
+    fn test_surrogates_are_stable_when_rows_shift() {
+        let row = ("", "2025-01-01", "Coffee", "-4.50");
+        let mut before = transactions(&[row]);
+        let mut after = transactions(&[("newer", "2025-06-01", "Newer row", "-9.99"), row]);
+
+        resolve_transaction_ids(&mut before);
+        resolve_transaction_ids(&mut after);
+
+        assert_eq!(
+            before.data()[0].transaction_id,
+            after.data()[1].transaction_id,
+            "the same row should keep its surrogate after another row is inserted above it"
+        );
+    }
+
+    /// The surrogate must not depend on anything the user edits locally, or an edit would re-key
+    /// the row.
+    #[test]
+    fn test_surrogates_ignore_locally_editable_fields() {
+        let mut txns = transactions(&[("", "2025-01-01", "Coffee", "-4.50")]);
+        resolve_transaction_ids(&mut txns);
+        let original_key = txns.data()[0].transaction_id.clone();
+
+        let mut edited = transactions(&[("", "2025-01-01", "Coffee", "-4.50")]);
+        edited.data_mut()[0].category = "Coffee Shops".to_string();
+        edited.data_mut()[0].note = "reimbursable".to_string();
+        resolve_transaction_ids(&mut edited);
+
+        assert_eq!(
+            original_key,
+            edited.data()[0].transaction_id,
+            "categorizing a row must not change its key"
+        );
+    }
+
+    /// The whole approach only works if the sheet round-trips unchanged.
+    #[test]
+    fn test_original_value_is_written_back() {
+        let mut txns = transactions(&[
+            ("", "2025-01-01", "Apple Card", "-1.00"),
+            ("split:[1]", "2025-01-02", "Split A", "-2.00"),
+            ("split:[1]", "2025-01-03", "Split B", "-3.00"),
+        ]);
+        let before = txns.to_rows().unwrap();
+
+        resolve_transaction_ids(&mut txns);
+        let after = txns.to_rows().unwrap();
+
+        assert_eq!(
+            before, after,
+            "the rows written back to the sheet must be identical to the rows read from it"
+        );
+    }
+
+    #[test]
+    fn test_report_names_the_sheet_row() {
+        let mut txns = transactions(&[
+            ("good-id", "2025-01-01", "One", "-1.00"),
+            ("", "2025-01-02", "Two", "-2.00"),
+        ]);
+
+        let report = resolve_transaction_ids(&mut txns);
+
+        assert_eq!(report.resolved.len(), 1);
+        // Data row index 1 is the third line of the sheet: header, good-id, then this one.
+        assert_eq!(report.resolved[0].sheet_row, 3);
+        assert_eq!(report.resolved[0].problem, IdProblem::Blank);
+    }
+
+    /// The hash is persisted as a primary key, so its output is part of the on-disk format.
+    #[test]
+    fn test_fnv1a_matches_the_published_vectors() {
+        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+        assert_eq!(fnv1a_64(b"a"), 0xaf63_dc4c_8601_ec8c);
+        assert_eq!(fnv1a_64(b"foobar"), 0x8594_4171_f739_67e8);
+    }
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -52,6 +52,14 @@ impl TestEnv {
         self.config.clone()
     }
 
+    /// Loads the seed data into the TestSheet associated with this environment.
+    ///
+    /// The sheet is normally seeded the first time a sync reaches for it. Call this when a test
+    /// needs to look at or edit the sheet before any sync has run.
+    pub fn seed_sheet(&self) {
+        let _ = TestSheet::new_with_seed_data(self.config.spreadsheet_id());
+    }
+
     /// Gets the current state of the TestSheet associated with this environment.
     pub fn get_state(&self) -> TestSheetState {
         let test_sheet = TestSheet::new(self.config.spreadsheet_id());


### PR DESCRIPTION
Fixes #34, #37 and #38.

Six commits. The first three are the substance; the rest are documentation and MCP surface changes that arrived with them.

---

## 1. `sync down` no longer aborts on unusable Transaction IDs (#37)

`sync down` aborts on the first row whose `Transaction ID` cannot serve as a primary key:

```
Database error: Failed to insert transaction
Caused by: (code: 1555) UNIQUE constraint failed: transactions.transaction_id
```

Real sheets violate the uniqueness assumption routinely. Of the 14,168 rows in the reported sheet, 774 were affected — 734 with a blank ID (723 of them Apple Card, a feed that supplies none) and 40 carrying literal `split:[1]` / `split:[2]` markers instead of the parent transaction's ID. Neither case means the row is corrupt, so the tool is unusable against an ordinary sheet until the user hand-repairs it, and the error names neither the offending ID nor its row.

**Approach.** Affected rows are given a surrogate `user-` ID for local use. The sheet's own value is stored in a new `original_transaction_id` column, and `get_by_header` returns that value in preference to the key — so `sync up` writes the original back and the Transactions tab round-trips byte-for-byte unchanged.

Resolution runs in the sheet-fetch path rather than in the sync commands, so every read of the sheet is normalized identically. `sync up` compares the `sync-down` snapshot against a fresh download and re-reads the sheet during verification; resolving in one command but not the other would make every `sync up` report a false conflict.

Surrogates are automatic rather than behind a flag: the round trip is lossless, so there is nothing to opt into, and blank IDs from a feed like Apple Card are a permanent property of the sheet rather than a one-off repair.

**Surrogate stability.** `sync down` upserts on `transaction_id`, so an ID that changed between syncs would make the row look deleted and re-added, discarding whatever the user had categorized or annotated. Surrogates are therefore derived from row content, not position:

```
user-<64-bit FNV-1a of: sheet ID value, date, amount, description, full description,
                        account, institution, + occurrence within a group of identical rows>
```

- Position is excluded — inserting a row above must not re-key everything below it.
- Locally-editable fields are excluded — categorizing or annotating a row must not re-key it.
- The amount contributes its numeric value, not its rendered string. An `Amount` retains the formatting it was parsed from, so reformatting the Amount column would otherwise re-key every affected row.
- Occurrence number is included — identical rows are plausible (same card, merchant, amount and day) and still need distinct keys.
- FNV-1a is written out rather than taken from `std::hash::DefaultHasher`, whose algorithm is explicitly allowed to change between Rust releases. These hashes are persisted as primary keys, so the algorithm is part of the on-disk format.

**Reporting.** A `warn!` names the counts by cause and gives the query that lists the affected rows; the first ten are named individually at `debug`.

**Migration.** Migration 03 adds `original_transaction_id`; `CURRENT_VERSION` goes to 3. The down migration drops the column and notes that a `sync down` is needed afterwards. The two `validate_migrations` tests are now derived from `CURRENT_VERSION` instead of hardcoding a version number.

---

## 2. `sync down` stops silently discarding local edits (#38)

The documented advice was "always run `sync_down` before making local edits". Taken at face value *after* editing, it is destructive: transactions are upserted from the sheet, overwriting local field values, and Categories and AutoCat are deleted outright and replaced.

Three changes:

**The advice is scoped.** `sync down` belongs at the start of a round of edits, never between editing and `sync up`. The docs now say what it does to unsynced work rather than describing it as a refresh — README, `INSTRUCTIONS.md`, `DESIGN.md`.

**`sync down` refuses when the datastore has diverged**, and names what would be lost:

```
Sync error: The local datastore has changes that are not in the sheet: 1 transaction
(0 added, 1 modified, 0 deleted). Running 'sync down' now would discard them. Run
'tiller sync up' first to upload them, or use --force to discard them and overwrite
with the sheet's contents. Use 'tiller status' to see the local and remote state.
```

`sync up` now records a new baseline after a successful upload, taken from the sheet as re-read during verification. Without it, the ordinary down → edit → up → down cycle would be permanently blocked by the edits just uploaded.

**`tiller status` / MCP `sync_status`** reports what has changed on each side since the last sync, modifying neither — the supported way to check for remote drift without a `sync down`.

```bash
tiller status               # local and remote
tiller status --local-only  # no network, no auth needed
```

**How rows are compared.** By their sheet representation — the same strings a `sync up` would write — rather than by typed fields. Comparing typed fields reports differences for values that round-trip through the database in a different but equivalent representation, and a check that cries wolf gets ignored. Two consequences, both deliberate:

- A field with no column in the sheet is not compared. It can never be uploaded, so a difference in it could never be cleared by a `sync up`, and `sync down` would be blocked forever.
- The unnamed column A is not compared. It has no database column, so it reads back empty and would make every row look modified.

Transactions and categories are keyed by primary key. AutoCat rules have no stable identity — the synthetic key is reassigned on every `sync down` — so they are compared as a multiset, which treats a reordering as no change.

`sync up`'s conflict message now names the counts, which `DESIGN.md` had always called for.

---

## 3. The OAuth browser flow is kept out of agent startup (#34)

Starting an agent session could pop a Google authorization window at the user and then hang, with no action on their part beyond launching the agent.

The MCP server is not the cause. `TokenProvider::initialize` — the only function that opens a browser — is reachable from exactly one place, `commands::auth`. Credentials are read in `api::sheet()`, which runs only when an operation needs the Google API. Launching `tiller mcp`, loading `Config`, opening the database, and the MCP `initialize` handshake touch none of it.

What reached it was an agent, in three steps: the old `INTRO.md` said it **MUST** call `initialize_service` first; that returned instructions whose first best practice was "always sync down first"; `sync_down` then failed on an expired token, and an agent that had just been told to initialize the service concluded the remedy was to run `tiller auth` in a shell.

Steps 1 and 2 are removed by items 2 and 4 in this PR. This commit closes step 3: `tiller auth` refuses to start unless stdin is a terminal.

```
$ tiller auth   # from a script or an agent's shell
Auth error: 'tiller auth' has to be run by a person at a terminal. It opens a browser
and waits for you to authorize there, so it cannot complete when started by a script, a
background process, or an AI agent. Open a terminal and run 'tiller auth' yourself.

To check existing credentials without any of that, use 'tiller auth --verify'.
```

There is no override flag, deliberately: the flow cannot complete without a person in a browser, so no non-interactive use of it can succeed. `tiller auth --verify` covers the scriptable case and is untouched. The terminal check runs before anything else in `initialize`, so a missing credentials file cannot mask the real problem.

The credential-failure error now states that a person has to run `tiller auth` in a terminal, and that an assistant should ask the user rather than run it itself.

---

## 4. MCP tools are no longer gated behind an initialization call

Every tool used to reject calls until `initialize_service` had been called once. The gate is gone, along with the flag, the macro, and the rejection response; tools are callable straight away, like any other MCP server.

`initialize_service` is replaced by `instructions`, returning the same guide as an ordinary optional tool. `ServerInfo.instructions` (`INTRO.md`) is rewritten as a short orientation — a client pays for it in context on every session, whether or not tiller is used. Anything an agent needs to use a tool safely lives in that tool's own description.

## 5 & 6. Documentation cleanups

The `Unreleased` changelog section had two entries duplicated verbatim under both `Fixed` and `Added`, left by earlier squash merges; the `Fixed` copies are kept. `AGENTS.md` and `DESIGN.md` each carried a paragraph describing the removed initialization gate rather than the project as it stands.

---

## Verification

`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (230 tests) pass.

Tests added: ten unit tests on ID resolution plus three end-to-end sync tests; twelve on change detection and the `sync down` guard; five on `status`; two on the terminal check for `tiller auth`; one asserting the MCP tools need no initialization call.

`test_sync_down_handles_blank_and_duplicate_ids` reproduces the reported `UNIQUE constraint failed` against the unpatched path. The `sync up` round-trip test asserts that no `user-` ID is ever written into the sheet. The `sync down` guard tests cover refusal, `--force` override, a clean datastore being unaffected, and down-after-up not being blocked. The `tiller auth` tests run without a terminal on stdin — the same condition an agent's shell is in — so they assert the real behavior rather than simulating it.

## Known gap

`categories.category` is also a primary key and would fail the same way on a sheet with a blank or duplicated category name. Not addressed here.

More broadly: Tiller writes rows with blank and repeated `Transaction ID` values, so that column cannot be the row identifier. This PR works around that for the affected rows but does not settle the identity question — see the discussion on #37.